### PR TITLE
[Feat] 회원가입 API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -1,8 +1,9 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { typeORMConfig } from "./configs/typeorm.config";
+import { UsersModule } from "./users/users.module";
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig)],
+  imports: [TypeOrmModule.forRoot(typeORMConfig), UsersModule],
 })
 export class AppModule {}

--- a/BE/src/configs/typeorm.config.ts
+++ b/BE/src/configs/typeorm.config.ts
@@ -10,4 +10,5 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   database: process.env.DB_NAME,
   entities: ["dist/**/*.entity{.ts,.js}"],
   synchronize: true,
+  timezone: "Asia/Seoul",
 };

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Post } from "@nestjs/common";
+import { UsersService } from "./users.service";
+import { CreateUserDto } from "./users.dto";
+
+@Controller("users")
+export class UsersController {
+  constructor(private usersService: UsersService) {}
+
+  @Post()
+  async registerUser(@Body() createUserDto: CreateUserDto): Promise<void> {
+    await this.usersService.registerUser(createUserDto);
+    return;
+  }
+}

--- a/BE/src/users/users.dto.ts
+++ b/BE/src/users/users.dto.ts
@@ -10,10 +10,12 @@ export class CreateUserDto {
 
   @IsString()
   nickname: string;
+}
 
-  @IsNumber()
-  credit: number;
+export class LoginUserDto {
+  @IsString()
+  userID: string;
 
-  @IsEnum(premiumStatus)
-  premium: premiumStatus;
+  @IsString()
+  password: string;
 }

--- a/BE/src/users/users.entity.ts
+++ b/BE/src/users/users.entity.ts
@@ -23,10 +23,10 @@ export class User extends BaseEntity {
   @Column({ length: 20 })
   nickname: string;
 
-  @Column()
+  @Column({ default: 0 })
   credit: number;
 
-  @Column({ type: "enum", enum: premiumStatus, default: premiumStatus.TRUE })
+  @Column({ type: "enum", enum: premiumStatus, default: premiumStatus.FALSE })
   premium: premiumStatus;
 
   @CreateDateColumn({ type: "datetime" })

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { UsersController } from "./users.controller";
+import { UsersService } from "./users.service";
+import { User } from "./users.entity";
+import { UsersRepository } from "./users.repository";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  controllers: [UsersController],
+  providers: [UsersService, UsersRepository],
+})
+export class UsersModule {}

--- a/BE/src/users/users.repository.ts
+++ b/BE/src/users/users.repository.ts
@@ -2,9 +2,12 @@ import { CreateUserDto } from "./users.dto";
 import { User } from "./users.entity";
 
 export class UsersRepository {
-  async createUser(createUserDto: CreateUserDto): Promise<User> {
-    const { userID, password, nickname } = createUserDto;
-
+  async createUser(
+    createUserDto: CreateUserDto,
+    encodedPassword: string,
+  ): Promise<User> {
+    const { userID, nickname } = createUserDto;
+    const password = encodedPassword;
     const newUser = User.create({ userID, password, nickname });
     await newUser.save();
 

--- a/BE/src/users/users.repository.ts
+++ b/BE/src/users/users.repository.ts
@@ -1,0 +1,13 @@
+import { CreateUserDto } from "./users.dto";
+import { User } from "./users.entity";
+
+export class UsersRepository {
+  async createUser(createUserDto: CreateUserDto): Promise<User> {
+    const { userID, password, nickname } = createUserDto;
+
+    const newUser = User.create({ userID, password, nickname });
+    await newUser.save();
+
+    return newUser;
+  }
+}

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -8,6 +8,7 @@ export class UsersService {
   constructor(private usersRepository: UsersRepository) {}
 
   async registerUser(createUserDto: CreateUserDto): Promise<User> {
-    return this.usersRepository.createUser(createUserDto);
+    const encodedPassword = btoa(createUserDto.password);
+    return this.usersRepository.createUser(createUserDto, encodedPassword);
   }
 }

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@nestjs/common";
+import { CreateUserDto } from "./users.dto";
+import { UsersRepository } from "./users.repository";
+import { User } from "./users.entity";
+
+@Injectable()
+export class UsersService {
+  constructor(private usersRepository: UsersRepository) {}
+
+  async registerUser(createUserDto: CreateUserDto): Promise<User> {
+    return this.usersRepository.createUser(createUserDto);
+  }
+}


### PR DESCRIPTION
## 요약

### 회원가입 API 구현
- `/users` API로 POST 요청 시 user 테이블에 유저 정보 추가 
- password 저장 시 base64 `btoa()` 를 통한 비밀번호 암호화

## 변경 사항

### [Fix] User Entity 파일명 수정 
- 이전에 엔티티를 통해 데이터베이스 테이블이 생성되지 않은 문제가 발생
- 파일명 수정 후 테이블 생성 확인

### 회원가입을 위한 POST 요청 처리
- users.controller, users.service, user.repository 구현
- `/users` 로 POST 요청 시 user 테이블에 추가
- `LoginUserDto` 생성

### Timezone을 typeorm.config 파일에 추가
- createdData 데코레이터 등 datetime을 자동으로 설정했을 때 timezone이 한국이 아닌 상태로 추가됨
- Timezone을 Asia/Seoul로 설정

**[ Postman으로 API 실행 결과 ]**

<img width="1366" alt="스크린샷 2023-11-14 오후 6 30 25" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/160df6c8-cb05-4634-a7ef-b92a0a1413a0">

## 참고 사항

- typeorm에서 create 명령은 실제로 데이터를 추가하지 않는다. save를 해야된다..!
- id는 에러가 나도 auto increment가 된다.

### 추가로 구현할 수 있는 사항

- repository 의존성 주입
- 비밀번호 암호화를 보안적으로 더 빡세게!
- 컨트롤러단에서 try-catch로 에러 검사 한번 더 하기
- userId가 존재하는지 확인하는 로직 추가?
- `createUserDto` → password를 암호화된 비밀번호와 상관없이 가져가는 것에 대한 처리?

## 이슈 번호

close #15
