### PR TITLE
[Feat] Diary Entity 및 DTO 생성

### DIFF
--- a/BE/src/configs/typeorm.config.ts
+++ b/BE/src/configs/typeorm.config.ts
@@ -10,5 +10,5 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   database: process.env.DB_NAME,
   entities: ["dist/**/*.entity{.ts,.js}"],
   synchronize: true,
-  timezone: "Asia/Seoul",
+  timezone: "+09:00",
 };

--- a/BE/src/diaries/diaries.dto.ts
+++ b/BE/src/diaries/diaries.dto.ts
@@ -1,0 +1,42 @@
+import { IsString, IsDate, Matches, IsUUID } from "class-validator";
+
+export class CreateDiaryDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  content: string;
+
+  @IsString()
+  @Matches(RegExp("^-?d+(.d+)?,-?d+(.d+)?,-?d+(.d+)?$"), {
+    message: "적절하지 않은 포인트 양식입니다",
+  })
+  point: string;
+
+  @IsDate()
+  date: Date;
+}
+
+export class ReadDiaryDto {
+  @IsUUID()
+  uuid: string;
+}
+
+export class UpdateDiaryDto {
+  @IsUUID()
+  uuid: string;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  content: string;
+
+  @IsDate()
+  date: Date;
+}
+
+export class DeleteDiaryDto {
+  @IsUUID()
+  uuid: string;
+}

--- a/BE/src/diaries/diaries.entity.ts
+++ b/BE/src/diaries/diaries.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  BaseEntity,
+  ManyToOne,
+  Generated,
+} from "typeorm";
+import { User } from "src/users/users.entity";
+
+@Entity()
+export class Diary extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: "uuid" })
+  @Generated("uuid")
+  uuid: string;
+
+  @ManyToOne(() => User, (user) => user.userId, { nullable: false })
+  user: User;
+
+  @Column()
+  title: string;
+
+  @Column({ type: "text" })
+  content: string;
+
+  @Column({ length: 7 })
+  color: string;
+
+  @Column()
+  date: Date;
+
+  @Column()
+  point: string;
+
+  @CreateDateColumn({ type: "datetime" })
+  createdDate: Date;
+
+  @UpdateDateColumn({ type: "datetime" })
+  updatedDate: Date;
+
+  @DeleteDateColumn({ type: "datetime" })
+  deletedDate: Date;
+}

--- a/BE/src/users/users.dto.ts
+++ b/BE/src/users/users.dto.ts
@@ -3,7 +3,7 @@ import { premiumStatus } from "src/utils/enum";
 
 export class CreateUserDto {
   @IsString()
-  userID: string;
+  userId: string;
 
   @IsString()
   password: string;
@@ -14,7 +14,7 @@ export class CreateUserDto {
 
 export class LoginUserDto {
   @IsString()
-  userID: string;
+  userId: string;
 
   @IsString()
   password: string;

--- a/BE/src/users/users.entity.ts
+++ b/BE/src/users/users.entity.ts
@@ -6,8 +6,10 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   BaseEntity,
+  OneToMany,
 } from "typeorm";
 import { premiumStatus } from "src/utils/enum";
+import { Diary } from "../diaries/diaries.entity";
 
 @Entity()
 export class User extends BaseEntity {
@@ -15,7 +17,7 @@ export class User extends BaseEntity {
   id: number;
 
   @Column({ length: 20, unique: true })
-  userID: string;
+  userId: string;
 
   @Column({ length: 20 })
   password: string;
@@ -37,4 +39,7 @@ export class User extends BaseEntity {
 
   @DeleteDateColumn({ type: "datetime" })
   deletedDate: Date;
+
+  @OneToMany(() => Diary, (diary) => diary.user)
+  diaries: Diary[];
 }

--- a/BE/src/users/users.repository.ts
+++ b/BE/src/users/users.repository.ts
@@ -6,9 +6,9 @@ export class UsersRepository {
     createUserDto: CreateUserDto,
     encodedPassword: string,
   ): Promise<User> {
-    const { userID, nickname } = createUserDto;
+    const { userId, nickname } = createUserDto;
     const password = encodedPassword;
-    const newUser = User.create({ userID, password, nickname });
+    const newUser = User.create({ userId, password, nickname });
     await newUser.save();
 
     return newUser;


### PR DESCRIPTION
## 요약

- Diary Entity 및 DTO 생성

## 변경 사항

### typeorm timezone 수정
- 아래와 같은 경고문구 발생
```
Ignoring invalid timezone passed to Connection: Asia/Seoul. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection
```
- TypeORM timezone을 `Asia/Seoul` 에서 `+09:00`으로 변경해서 해결. 다른 형식이나 동일한 뜻을 가짐.

### Diary Entity 및 DTO 생성
- `class-validator`를 활용하여 DTO 유효성 검사
- User Entity와 FK 설정
| 참고: https://typeorm.io/many-to-one-one-to-many-relations
```tsx
@ManyToOne(() => User, (user) => user.userId, { nullable: false })
  user: User;
```
  - 위와 같이 작성 시 자동으로 컬럼명이 userId로 입력됨
  - User 엔티티에 해당 User가 작성한 diaries가 관리됨. 실제로 DB에 저장되지는 않으나 런타임 단계에서 꺼낼 수 있을 것으로 예상
  - 통일을 위해서 `userID` → `userId` 로 네이밍 수정
- uuid는 `@Generated()` 데코레이터를 사용해 자동 생성
- 좌표 데이터는 string(1,2,3) 형식으로 저장
  - 이에 해당하는 정규식 검사 추가
  ```tsx
  @Matches(RegExp("^-?d+(.d+)?,-?d+(.d+)?,-?d+(.d+)?$"), {
    message: "적절하지 않은 포인트 양식입니다",
  })
  ```

[생성 결과]

![image](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/38f8506b-4f7a-4ece-8cde-d9462c2947b4)


## 참고 사항

### mysql 3차원 좌표 저장
- [Point](https://dev.mysql.com/doc/refman/8.0/en/gis-class-point.html)는 2차원 데이터만 지원
- 일단 string으로 저장하기(형식: `1,2,3`)

### 추가 구현사항

- 모양, 태그 엔티티, DTO를 미리 생성해두고 일기 CRUD 구현하도록 계획 수정
- 별자리 선 테이블의 경우 현재 일기 테이블에 미치는 영향이 없기 때문에 추후 기능 구현 시 추가 예정
- 별 위치(좌표) 바뀌는 기능이 만약 생기면? UpdateDiaryDto에 컬럼 추가하기

## 이슈 번호

close #26

