### PR TITLE
[Feat] Diary 초기 코드 템플릿 및 감정분석 컬럼 추가

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -2,8 +2,9 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { typeORMConfig } from "./configs/typeorm.config";
 import { UsersModule } from "./users/users.module";
+import { DiariesModule } from "./diaries/diaries.module";
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig), UsersModule],
+  imports: [TypeOrmModule.forRoot(typeORMConfig), UsersModule, DiariesModule],
 })
 export class AppModule {}

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -1,0 +1,8 @@
+import { Body, Controller, Post } from "@nestjs/common";
+import { DiariesService } from "./diaries.service";
+import { CreateDiaryDto } from "./diaries.dto";
+
+@Controller("diaries")
+export class DiariesController {
+  constructor(private diariesService: DiariesService) {}
+}

--- a/BE/src/diaries/diaries.entity.ts
+++ b/BE/src/diaries/diaries.entity.ts
@@ -11,6 +11,7 @@ import {
 } from "typeorm";
 import { User } from "src/users/users.entity";
 import { Shape } from "src/shapes/shapes.entity";
+import { sentimentStatus } from "src/utils/enum";
 
 @Entity()
 export class Diary extends BaseEntity {
@@ -35,6 +36,22 @@ export class Diary extends BaseEntity {
 
   @Column({ length: 7 })
   color: string;
+
+  @Column({ type: "float" })
+  positiveRatio: number;
+
+  @Column({ type: "float" })
+  negativeRatio: number;
+
+  @Column({ type: "float" })
+  neutralRatio: number;
+
+  @Column({
+    type: "enum",
+    enum: sentimentStatus,
+    default: sentimentStatus.ERROR,
+  })
+  sentiment: sentimentStatus;
 
   @Column()
   date: Date;

--- a/BE/src/diaries/diaries.module.ts
+++ b/BE/src/diaries/diaries.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { DiariesController } from "./diaries.controller";
+import { DiariesService } from "./diaries.service";
+import { DiariesRepository } from "./diaries.repository";
+import { Diary } from "./diaries.entity";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Diary])],
+  controllers: [DiariesController],
+  providers: [DiariesService, DiariesRepository],
+})
+export class DiariesModule {}

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -1,0 +1,3 @@
+import { Diary } from "./diaries.entity";
+
+export class DiariesRepository {}

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+import { DiariesRepository } from "./diaries.repository";
+import { Diary } from "./diaries.entity";
+
+@Injectable()
+export class DiariesService {
+  constructor(private diariesRepository: DiariesRepository) {}
+}

--- a/BE/src/utils/enum.ts
+++ b/BE/src/utils/enum.ts
@@ -2,3 +2,10 @@ export enum premiumStatus {
   TRUE = "TRUE",
   FALSE = "FALSE",
 }
+
+export enum sentimentStatus {
+  POSITIVE = "positive",
+  NEGATIVE = "negative",
+  NEUTRAL = "neutral",
+  ERROR = "error",
+}


### PR DESCRIPTION
## 요약

- Diary 코드 초기 템플릿 설정
- Diary Entity에 감정분석 컬럼 추가

## 변경 사항

### Diary 코드 초기 템플릿 설정
- Controller, Service, Repository, Module 추가

### Diary Entity에 감정분석 컬럼 추가
- Enum sentimentStatus 정의
- positiveRatio, negativeRatio, neutralRatio를 float로 설정

<img width="1044" alt="스크린샷 2023-11-15 오후 2 19 24" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/02eb8d0b-5ba8-4bda-b697-46e54c203fa3">

## 참고 사항
- 감정분석 컬럼이 추가되면서 ERD 수정

## 이슈 번호
close #30
