### PR TITLE
[Feat] 일기 생성 API 구현

### DIFF
--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -1,8 +1,15 @@
 import { Body, Controller, Post } from "@nestjs/common";
 import { DiariesService } from "./diaries.service";
 import { CreateDiaryDto } from "./diaries.dto";
+import { Diary } from "./diaries.entity";
 
 @Controller("diaries")
 export class DiariesController {
   constructor(private diariesService: DiariesService) {}
+
+  @Post()
+  async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<void>{
+    await this.diariesService.writeDiary(createDiaryDto);
+    return;
+  }
 }

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -5,7 +5,7 @@ import { sentimentStatus } from "src/utils/enum";
 import { Shape } from "src/shapes/shapes.entity";
 
 export class DiariesRepository {
-  async insertDiary(createDiaryDto: CreateDiaryDto, encodedContent: string): Promise<Diary>{
+  async createDiary(createDiaryDto: CreateDiaryDto, encodedContent: string): Promise<Diary>{
     const {title, point, date} = createDiaryDto;
       const content = encodedContent;
 

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -1,3 +1,38 @@
+import { User } from "src/users/users.entity";
+import { CreateDiaryDto } from "./diaries.dto";
 import { Diary } from "./diaries.entity";
+import { sentimentStatus } from "src/utils/enum";
+import { Shape } from "src/shapes/shapes.entity";
 
-export class DiariesRepository {}
+export class DiariesRepository {
+  async insertDiary(createDiaryDto: CreateDiaryDto, encodedContent: string): Promise<Diary>{
+    const {title, point, date} = createDiaryDto;
+      const content = encodedContent;
+
+      // 미구현 기능을 대체하기 위한 임시 값
+      const color = "#FFFFFF";
+      const positiveRatio = 0.0;
+      const negativeRatio = 100.0;
+      const neutralRatio = 0.0;
+      const sentiment = sentimentStatus.NEUTRAL;
+      const shape = await Shape.findOne({where: {id: 1}});
+      const user = await User.findOne({where: {id: 1}});
+
+      const newDiary = Diary.create({
+          title,
+          content,
+          point,
+          date,
+          color,
+          positiveRatio,
+          negativeRatio,
+          neutralRatio,
+          sentiment,
+          shape: { id: shape.id },
+          user: { id: user.id },
+        });
+        await newDiary.save();
+
+      return newDiary;
+  }
+}

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -1,8 +1,14 @@
 import { Injectable } from "@nestjs/common";
 import { DiariesRepository } from "./diaries.repository";
 import { Diary } from "./diaries.entity";
+import { CreateDiaryDto } from "./diaries.dto";
 
 @Injectable()
 export class DiariesService {
   constructor(private diariesRepository: DiariesRepository) {}
+
+  async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary>{
+    const encodedContent = btoa(createDiaryDto.content);
+    return this.diariesRepository.insertDiary(createDiaryDto, encodedContent);
+  }
 }

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -9,6 +9,6 @@ export class DiariesService {
 
   async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary>{
     const encodedContent = btoa(createDiaryDto.content);
-    return this.diariesRepository.insertDiary(createDiaryDto, encodedContent);
+    return this.diariesRepository.createDiary(createDiaryDto, encodedContent);
   }
 }


### PR DESCRIPTION
## 요약

- /diaries POST 요청 처리

## 변경 사항

### /diaries POST 요청 처리
- diaries.controller, diaries.service에 writeDiary 메서드 구현
- diaries.repository에 DB에 일기 데이터를 저장하는 insertDiary 메서드 구현
- 일기의 content는 btoa()를 활용하여 base64로 암호화하여 저장

## 참고 사항

```
No overload matches this call.
  Overload 1 of 3, '(this: (new () => Diary) & typeof BaseEntity, entityLikeArray: DeepPartial<Diary>[]): Diary[]', gave the following error.
    Argument of type '{ title: string; content: string; point: string; date: Date; color: string; positiveRatio: number; negativeRatio: number; neutralRatio: number; sentiment: sentimentStatus; shape: number; user: { ...; }; }' is not assignable to parameter of type 'DeepPartial<Diary>[]'.
      Object literal may only specify known properties, and 'title' does not exist in type 'DeepPartial<Diary>[]'.
  Overload 2 of 3, '(this: (new () => Diary) & typeof BaseEntity, entityLike: DeepPartial<Diary>): Diary', gave the following error.
    Type 'number' is not assignable to type 'DeepPartial<Shape>'.
```
- 외래 키로 묶인 칼럼의 값을 저장하려고 할 때 일반적인 값을 입력하게 되면 위와 같은 오류가 발생한다.
- 따라서 엔티티 클래스를 통해 객체를 찾아 id값을 전달하는 방식으로 구현하여 해결했다.

## 이슈 번호
close #34 

