### PR TITLE
[Feat] 일기 수정 PUT API 구현

### DIFF
--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Post } from "@nestjs/common";
+import { Body, Controller, Post, Put } from "@nestjs/common";
 import { DiariesService } from "./diaries.service";
-import { CreateDiaryDto } from "./diaries.dto";
+import { CreateDiaryDto, UpdateDiaryDto } from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 
 @Controller("diaries")
@@ -8,8 +8,13 @@ export class DiariesController {
   constructor(private diariesService: DiariesService) {}
 
   @Post()
-  async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<void>{
+  async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<void> {
     await this.diariesService.writeDiary(createDiaryDto);
     return;
+  }
+
+  @Put()
+  modifyDiary(@Body() updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
+    return this.diariesService.modifyDiary(updateDiaryDto);
   }
 }

--- a/BE/src/diaries/diaries.dto.ts
+++ b/BE/src/diaries/diaries.dto.ts
@@ -34,6 +34,9 @@ export class UpdateDiaryDto {
 
   @IsDate()
   date: Date;
+
+  @IsString()
+  shapeUuid: string;
 }
 
 export class DeleteDiaryDto {

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -1,38 +1,66 @@
 import { User } from "src/users/users.entity";
-import { CreateDiaryDto } from "./diaries.dto";
+import { CreateDiaryDto, UpdateDiaryDto } from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 import { sentimentStatus } from "src/utils/enum";
 import { Shape } from "src/shapes/shapes.entity";
+import { NotFoundException } from "@nestjs/common";
 
 export class DiariesRepository {
-  async createDiary(createDiaryDto: CreateDiaryDto, encodedContent: string): Promise<Diary>{
-    const {title, point, date} = createDiaryDto;
-      const content = encodedContent;
+  async createDiary(
+    createDiaryDto: CreateDiaryDto,
+    encodedContent: string,
+  ): Promise<Diary> {
+    const { title, point, date } = createDiaryDto;
+    const content = encodedContent;
 
-      // 미구현 기능을 대체하기 위한 임시 값
-      const color = "#FFFFFF";
-      const positiveRatio = 0.0;
-      const negativeRatio = 100.0;
-      const neutralRatio = 0.0;
-      const sentiment = sentimentStatus.NEUTRAL;
-      const shape = await Shape.findOne({where: {id: 1}});
-      const user = await User.findOne({where: {id: 1}});
+    // 미구현 기능을 대체하기 위한 임시 값
+    const color = "#FFFFFF";
+    const positiveRatio = 0.0;
+    const negativeRatio = 100.0;
+    const neutralRatio = 0.0;
+    const sentiment = sentimentStatus.NEUTRAL;
+    const shape = await Shape.findOne({ where: { id: 1 } });
+    const user = await User.findOne({ where: { id: 1 } });
 
-      const newDiary = Diary.create({
-          title,
-          content,
-          point,
-          date,
-          color,
-          positiveRatio,
-          negativeRatio,
-          neutralRatio,
-          sentiment,
-          shape: { id: shape.id },
-          user: { id: user.id },
-        });
-        await newDiary.save();
+    const newDiary = Diary.create({
+      title,
+      content,
+      point,
+      date,
+      color,
+      positiveRatio,
+      negativeRatio,
+      neutralRatio,
+      sentiment,
+      shape: { id: shape.id },
+      user: { id: user.id },
+    });
+    await newDiary.save();
 
-      return newDiary;
+    return newDiary;
+  }
+
+  async updateDiary(
+    updateDiaryDto: UpdateDiaryDto,
+    encodedContent: string,
+  ): Promise<Diary> {
+    const { uuid, title, date, shapeUuid } = updateDiaryDto;
+    const diary = await this.getDiaryByUuid(uuid);
+
+    diary.title = title;
+    diary.date = date;
+    diary.content = encodedContent;
+    diary.shape = await Shape.findOne({ where: { uuid: shapeUuid } });
+
+    await diary.save();
+    return diary;
+  }
+
+  async getDiaryByUuid(uuid: string): Promise<Diary> {
+    const found = await Diary.findOneBy({ uuid });
+    if (!found) {
+      throw new NotFoundException(`Can't find Diary with uuid: [${uuid}]`);
+    }
+    return found;
   }
 }

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -1,14 +1,19 @@
 import { Injectable } from "@nestjs/common";
 import { DiariesRepository } from "./diaries.repository";
 import { Diary } from "./diaries.entity";
-import { CreateDiaryDto } from "./diaries.dto";
+import { CreateDiaryDto, UpdateDiaryDto } from "./diaries.dto";
 
 @Injectable()
 export class DiariesService {
   constructor(private diariesRepository: DiariesRepository) {}
 
-  async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary>{
+  async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary> {
     const encodedContent = btoa(createDiaryDto.content);
     return this.diariesRepository.createDiary(createDiaryDto, encodedContent);
+  }
+
+  async modifyDiary(updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
+    const encodedContent = btoa(updateDiaryDto.content);
+    return this.diariesRepository.updateDiary(updateDiaryDto, encodedContent);
   }
 }


### PR DESCRIPTION
## 요약

- /diaries PUT 요청 처리

## 변경 사항

### /diaries PUT 요청 처리
- diaries.controller, diaries.service에 modifyDiary 메서드 구현
- diaries.repository에 DB에 일기 데이터를 저장하는 updateDiary 메서드 구현
- 일기의 content는 create할 때와 동일하게 btoa()를 활용하여 base64로 암호화하여 저장
- Shape.uuid를 통해 FK 추가

<img src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/c8111188-3bdf-41a7-af72-f65f1a62e76d" width=400 />


## 참고 사항

- PUT은 값을 덮어씌우는 역할로 POST와 차이가 있음
- 나중에 감정분석이 들어갈 경우 서비스 단에서 리포지토리에 인자로 넣어주기
- PR이 꼬여서 다시 branch를 파고 진행..
  - fetch -> rebase 후 commit하기..! 충돌은 어떻게 처리될 지 아직 모르겠음

## 이슈 번호
close #35

