### PR TITLE
[Feat] 일기 읽기 API 구현

### DIFF
--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -8,36 +8,36 @@ export class DiariesController {
   constructor(private diariesService: DiariesService) {}
 
   @Post()
-  async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<void>{
+  async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<void> {
     await this.diariesService.writeDiary(createDiaryDto);
     return;
   }
 
   @Get(":uuid")
-  async readDiary(@Param("uuid") uuid: string): Promise<string>{
-    const readDiaryDto : ReadDiaryDto = { uuid };
+  async readDiary(@Param("uuid") uuid: string): Promise<string> {
+    const readDiaryDto: ReadDiaryDto = { uuid };
     const diary = await this.diariesService.readDiary(readDiaryDto);
-    
+
     const response = JSON.stringify({
-      "userId" : diary.user.userId,
-      "title" : diary.title,
-      "content" : diary.content,
-      "date" : diary.date,
-      "tags" : [],
-      "emotion" : {
-        "positive" : diary.positiveRatio,
-        "neutral" : diary.neutralRatio,
-        "negative" : diary.negativeRatio,
-        "sentiment" : diary.sentiment,
+      userId: diary.user.userId,
+      title: diary.title,
+      content: diary.content,
+      date: diary.date,
+      tags: [],
+      emotion: {
+        positive: diary.positiveRatio,
+        neutral: diary.neutralRatio,
+        negative: diary.negativeRatio,
+        sentiment: diary.sentiment,
       },
-      "coordinate" : {
-        "x" : diary.point.split(',')[0],
-        "y" : diary.point.split(',')[1],
-        "z" : diary.point.split(',')[2],
+      coordinate: {
+        x: diary.point.split(",")[0],
+        y: diary.point.split(",")[1],
+        z: diary.point.split(",")[2],
       },
-      "shape_uuid" : diary.shape.uuid,
+      shape_uuid: diary.shape.uuid,
     });
-    
+
     return response;
   }
 }

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Post } from "@nestjs/common";
+import { Body, Controller, Get, Post, Param } from "@nestjs/common";
 import { DiariesService } from "./diaries.service";
-import { CreateDiaryDto } from "./diaries.dto";
+import { CreateDiaryDto, ReadDiaryDto } from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 
 @Controller("diaries")
@@ -11,5 +11,33 @@ export class DiariesController {
   async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<void>{
     await this.diariesService.writeDiary(createDiaryDto);
     return;
+  }
+
+  @Get(":uuid")
+  async readDiary(@Param("uuid") uuid: string): Promise<string>{
+    const readDiaryDto : ReadDiaryDto = { uuid };
+    const diary = await this.diariesService.readDiary(readDiaryDto);
+    
+    const response = JSON.stringify({
+      "userId" : diary.user.userId,
+      "title" : diary.title,
+      "content" : diary.content,
+      "date" : diary.date,
+      "tags" : [],
+      "emotion" : {
+        "positive" : diary.positiveRatio,
+        "neutral" : diary.neutralRatio,
+        "negative" : diary.negativeRatio,
+        "sentiment" : diary.sentiment,
+      },
+      "coordinate" : {
+        "x" : diary.point.split(',')[0],
+        "y" : diary.point.split(',')[1],
+        "z" : diary.point.split(',')[2],
+      },
+      "shape_uuid" : diary.shape.uuid,
+    });
+    
+    return response;
   }
 }

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -1,5 +1,5 @@
 import { User } from "src/users/users.entity";
-import { CreateDiaryDto } from "./diaries.dto";
+import { CreateDiaryDto, ReadDiaryDto } from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 import { sentimentStatus } from "src/utils/enum";
 import { Shape } from "src/shapes/shapes.entity";
@@ -34,5 +34,11 @@ export class DiariesRepository {
         await newDiary.save();
 
       return newDiary;
+  }
+
+  async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary>{
+    const uuid = readDiaryDto.uuid;
+    const diary = Diary.findOne({where: {uuid: uuid}, relations: ['user', 'shape']});
+    return diary;
   }
 }

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -5,40 +5,46 @@ import { sentimentStatus } from "src/utils/enum";
 import { Shape } from "src/shapes/shapes.entity";
 
 export class DiariesRepository {
-  async createDiary(createDiaryDto: CreateDiaryDto, encodedContent: string): Promise<Diary>{
-    const {title, point, date} = createDiaryDto;
-      const content = encodedContent;
+  async createDiary(
+    createDiaryDto: CreateDiaryDto,
+    encodedContent: string,
+  ): Promise<Diary> {
+    const { title, point, date } = createDiaryDto;
+    const content = encodedContent;
 
-      // 미구현 기능을 대체하기 위한 임시 값
-      const color = "#FFFFFF";
-      const positiveRatio = 0.0;
-      const negativeRatio = 100.0;
-      const neutralRatio = 0.0;
-      const sentiment = sentimentStatus.NEUTRAL;
-      const shape = await Shape.findOne({where: {id: 1}});
-      const user = await User.findOne({where: {id: 1}});
+    // 미구현 기능을 대체하기 위한 임시 값
+    const color = "#FFFFFF";
+    const positiveRatio = 0.0;
+    const negativeRatio = 100.0;
+    const neutralRatio = 0.0;
+    const sentiment = sentimentStatus.NEUTRAL;
+    const shape = await Shape.findOne({ where: { id: 1 } });
+    const user = await User.findOne({ where: { id: 1 } });
 
-      const newDiary = Diary.create({
-          title,
-          content,
-          point,
-          date,
-          color,
-          positiveRatio,
-          negativeRatio,
-          neutralRatio,
-          sentiment,
-          shape: { id: shape.id },
-          user: { id: user.id },
-        });
-        await newDiary.save();
+    const newDiary = Diary.create({
+      title,
+      content,
+      point,
+      date,
+      color,
+      positiveRatio,
+      negativeRatio,
+      neutralRatio,
+      sentiment,
+      shape: { id: shape.id },
+      user: { id: user.id },
+    });
+    await newDiary.save();
 
-      return newDiary;
+    return newDiary;
   }
 
-  async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary>{
+  async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary> {
     const uuid = readDiaryDto.uuid;
-    const diary = Diary.findOne({where: {uuid: uuid}, relations: ['user', 'shape']});
+    const diary = Diary.findOne({
+      where: { uuid: uuid },
+      relations: ["user", "shape"],
+    });
     return diary;
   }
 }

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { DiariesRepository } from "./diaries.repository";
 import { Diary } from "./diaries.entity";
-import { CreateDiaryDto } from "./diaries.dto";
+import { CreateDiaryDto, ReadDiaryDto } from "./diaries.dto";
 
 @Injectable()
 export class DiariesService {
@@ -10,5 +10,11 @@ export class DiariesService {
   async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary>{
     const encodedContent = btoa(createDiaryDto.content);
     return this.diariesRepository.createDiary(createDiaryDto, encodedContent);
+  }
+
+  async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary>{
+    let diary = await this.diariesRepository.readDiary(readDiaryDto);
+    diary.content = atob(diary.content);
+    return diary;
   }
 }

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -7,12 +7,12 @@ import { CreateDiaryDto, ReadDiaryDto } from "./diaries.dto";
 export class DiariesService {
   constructor(private diariesRepository: DiariesRepository) {}
 
-  async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary>{
+  async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary> {
     const encodedContent = btoa(createDiaryDto.content);
     return this.diariesRepository.createDiary(createDiaryDto, encodedContent);
   }
 
-  async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary>{
+  async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary> {
     let diary = await this.diariesRepository.readDiary(readDiaryDto);
     diary.content = atob(diary.content);
     return diary;


### PR DESCRIPTION
## 요약
- /diaries GET 요청 처리

## 변경 사항

### /diaries GET 요청 처리

- diaries.controller, diaries.service, diaries.repository에 readDiary 메서드 구현
- diaries.controller에서 클라이언트에 전달할 응답을 구성
<img width="640" alt="postman1" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/499e7b01-610b-4061-be9e-1781e83587c2">

## 참고 사항

- Get(":uuid")와 Get("/:uuid") 모두 동일하게 처리가 되는 것을 알아서, 명시적으로 Get("/:uuid") 으로 하도록 결정했습니다.
- ReadDiaryDto의 아이템이 uuid 1개밖에 없어서 그냥 uuid를 바로 사용할까 했으나 Dto로 주고받는 것이 더 코드 스타일 상 옳은 것 같아 Dto로 주고받도록 구현했습니다.
- conflict를 처음 마주쳤는데 생각보다 온건하게 처리가 되어서 다행이라고 생각했습니다..

## 이슈 번호
close #38

