### PR TITLE
[Feat] 일기 삭제 DELETE API 구현

### DIFF
--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -1,6 +1,19 @@
-import { Body, Controller, Get, Post, Param, Put } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from "@nestjs/common";
 import { DiariesService } from "./diaries.service";
-import { CreateDiaryDto, ReadDiaryDto, UpdateDiaryDto } from "./diaries.dto";
+import {
+  CreateDiaryDto,
+  DeleteDiaryDto,
+  ReadDiaryDto,
+  UpdateDiaryDto,
+} from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 
 @Controller("diaries")
@@ -44,5 +57,11 @@ export class DiariesController {
   @Put()
   modifyDiary(@Body() updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
     return this.diariesService.modifyDiary(updateDiaryDto);
+  }
+
+  @Delete("/:uuid")
+  deleteBoard(@Param("uuid") uuid: string): Promise<void> {
+    const deleteDiaryDto: DeleteDiaryDto = { uuid };
+    return this.diariesService.deleteDiary(deleteDiaryDto);
   }
 }

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -1,5 +1,10 @@
 import { User } from "src/users/users.entity";
-import { CreateDiaryDto, ReadDiaryDto, UpdateDiaryDto } from "./diaries.dto";
+import {
+  CreateDiaryDto,
+  DeleteDiaryDto,
+  ReadDiaryDto,
+  UpdateDiaryDto,
+} from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 import { sentimentStatus } from "src/utils/enum";
 import { Shape } from "src/shapes/shapes.entity";
@@ -63,6 +68,13 @@ export class DiariesRepository {
 
     await diary.save();
     return diary;
+  }
+
+  async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {
+    const { uuid } = deleteDiaryDto;
+    const diary = await this.getDiaryByUuid(uuid);
+
+    await Diary.softRemove(diary);
   }
 
   async getDiaryByUuid(uuid: string): Promise<Diary> {

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from "@nestjs/common";
 import { DiariesRepository } from "./diaries.repository";
 import { Diary } from "./diaries.entity";
-import { CreateDiaryDto, ReadDiaryDto, UpdateDiaryDto } from "./diaries.dto";
+import {
+  CreateDiaryDto,
+  DeleteDiaryDto,
+  ReadDiaryDto,
+  UpdateDiaryDto,
+} from "./diaries.dto";
 
 @Injectable()
 export class DiariesService {
@@ -21,5 +26,9 @@ export class DiariesService {
   async modifyDiary(updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
     const encodedContent = btoa(updateDiaryDto.content);
     return this.diariesRepository.updateDiary(updateDiaryDto, encodedContent);
+  }
+
+  async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {
+    return this.diariesRepository.deleteDiary(deleteDiaryDto);
   }
 }


### PR DESCRIPTION
## 요약

- `/diaries/:uuid` DELETE 요청 처리

## 변경 사항

### /diaries/:uuid DELETE 요청 처리
- diaries.controller, diaries.service에 deleteDiary 메서드 구현
- diaries.repository에 DB에 일기 데이터를 삭제하는 deleteDiary 메서드 구현
  - soft delete 방식으로 삭제 → 올바른 uuid로 삭제 시 deletedDate 컬럼 값이 변경됨
  - 이미 soft delete로 삭제된 값을 다시 삭제 시 error

**[테이블에서 일기 삭제 반영 결과]**

<img width="1084" alt="스크린샷 2023-11-15 오후 6 11 08" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/81968390-29aa-4d4e-99ee-4664da36ea09">

**[이미 soft delete로 삭제된 일기를 다시 삭제 시 응답]**

<img width="576" alt="스크린샷 2023-11-15 오후 6 12 11" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/1eb6b51a-509b-4e70-a8ea-b51222f2b1aa">




## 참고 사항

- 검색했을 때 Typeorm에서 제공한다고 하는 softDelete() 함수가 있다고 했는데 없었음..
- 따라서 softRemove()를 사용하고 이전에 getDiaryByUuid() 함수를 통해 해당하는 엔티티 레코드 찾음

## 이슈 번호
close #43

