### PR TITLE
[Feat] 일기 API CRUD e2e 테스트 코드 작성

### DIFF
--- a/BE/src/configs/typeorm.config.ts
+++ b/BE/src/configs/typeorm.config.ts
@@ -12,3 +12,15 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   synchronize: true,
   timezone: "+09:00",
 };
+
+export const typeORMTestConfig: TypeOrmModuleOptions = {
+  type: "mysql",
+  host: process.env.DB_HOST,
+  port: 3306,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: process.env.DB_NAME,
+  entities: ["src/**/*.entity{.ts,.js}"],
+  synchronize: true,
+  timezone: "+09:00",
+};

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -21,13 +21,12 @@ export class DiariesController {
   constructor(private diariesService: DiariesService) {}
 
   @Post()
-  async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<void> {
-    await this.diariesService.writeDiary(createDiaryDto);
-    return;
+  async writeDiary(@Body() createDiaryDto: CreateDiaryDto): Promise<Diary> {
+    return this.diariesService.writeDiary(createDiaryDto);
   }
 
   @Get("/:uuid")
-  async readDiary(@Param("uuid") uuid: string): Promise<string> {
+  async readDiary(@Param("uuid") uuid: string): Promise<String> {
     const readDiaryDto: ReadDiaryDto = { uuid };
     const diary = await this.diariesService.readDiary(readDiaryDto);
 

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -20,6 +20,8 @@ export class DiariesService {
   async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary> {
     let diary = await this.diariesRepository.readDiary(readDiaryDto);
     diary.content = atob(diary.content);
+    // Mysql DB에서 가져온 UST 날짜 데이터를 KST로 변경
+    diary.date.setHours(diary.date.getHours() + 9);
     return diary;
   }
 

--- a/BE/test/app.e2e-spec.ts
+++ b/BE/test/app.e2e-spec.ts
@@ -48,7 +48,6 @@ describe("AppController (e2e)", () => {
         point: "1.5,5.5,10.55",
         date: "2023-11-14",
       });
-    console.log(postResponse);
     const createdDiaryUuid = postResponse.body.uuid;
 
     const getResponse = await request(app.getHttpServer()).get(
@@ -88,7 +87,6 @@ describe("AppController (e2e)", () => {
         shapeUuid: "test",
       });
     const body = putResponse.body;
-    console.log(body);
 
     expect(body.title).toBe("업데이트 확인");
     expect(atob(body.content)).toBe("this is content222.");

--- a/BE/test/app.e2e-spec.ts
+++ b/BE/test/app.e2e-spec.ts
@@ -1,24 +1,43 @@
-// import { Test, TestingModule } from "@nestjs/testing";
-// import { INestApplication } from "@nestjs/common";
-// import * as request from "supertest";
-// import { AppModule } from "../src/app.module";
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "../src/app.module";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { typeORMTestConfig } from "src/configs/typeorm.config";
 
-// describe("AppController (e2e)", () => {
-//   let app: INestApplication;
+describe("AppController (e2e)", () => {
+  let app: INestApplication;
 
-//   beforeEach(async () => {
-//     const moduleFixture: TestingModule = await Test.createTestingModule({
-//       imports: [AppModule],
-//     }).compile();
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig), AppModule],
+    }).compile();
 
-//     app = moduleFixture.createNestApplication();
-//     await app.init();
-//   });
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
 
-//   it("/ (GET)", () => {
-//     return request(app.getHttpServer())
-//       .get("/")
-//       .expect(200)
-//       .expect("Hello World!");
-//   });
-// });
+  it("/diaries POST 201", () => {
+    return request(app.getHttpServer())
+      .post("/diaries")
+      .send({
+        title: "title",
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        date: "2023-11-14",
+      })
+      .expect(201);
+  });
+
+  it("/diaries/:uuid  GET 200", async () => {
+    const response = await request(app.getHttpServer()).get(
+      "/diaries/f5ef12ad-b3bd-4de0-b4ee-92f2265b0e90",
+    );
+    const body = JSON.parse(response.text);
+
+    expect(body.userId).toBe("jeongmin");
+    expect(body.title).toBe("jskim");
+    expect(body.content).toBe("this is jskim.");
+    expect(body.date).toBe("2023-11-13T15:00:00.000Z");
+  });
+});

--- a/BE/test/jest-e2e.json
+++ b/BE/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
## 요약

- 일기 API CRUD e2e 테스트 코드 작성
- Date 객체 시간을 KST로 변환

## 변경 사항

### 일기 API CRUD e2e 테스트 코드 작성

- jest 초기 세팅 진행
- 각 테스트가 독립되어 돌아가기 위해 데이터를 생성 후 삭제하도록 구현
- 현재는 config 파일에서 실제 DB와 통신
- READ: response.body가 아닌 response.text에 값이 들어가있음

<img width="374" alt="스크린샷 2023-11-16 오후 1 41 50" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/5f530eba-cde7-46f4-94ee-7a4fc79fae8f">

### Datetime 객체 시간 KST로 변경

- mysql 서버 시간은 KST로 되어있지만, typeorm에서 가져올 때 자동으로 UTC로 변환되어 가져옴
- 서비스 단에서 직접 9시간을 더해주어 반환

## 참고 사항

- DTO에서 undefined를 검사해주지 않아 수정 필요
- 현재는 config 파일에서 실제 DB와 통신 -> Test 데이터베이스로 변경 필요

## 이슈 번호

 close #42

