### PR TITLE
[Deploy] Github Action을 통한 CI/CD 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   be-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: SSH-deploy
         uses: appleboy/ssh-action@master
@@ -21,5 +21,23 @@ jobs:
             git pull origin main
             cd BE
             npm install --force
-            npm run build
-            npm restart
+            killall node
+            npm start
+  fe-deploy:
+    needs: be-deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - name: SSH-deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{secrets.VPC_HOST}}
+          username: ${{secrets.VPC_USER}}
+          password: ${{secrets.VPC_PASSWORD}}
+          port: ${{secrets.VPC_PORT}}
+          script: |
+            whoami
+            cd /home/web08-ByeolSoop
+            git pull origin main
+            cd FE
+            npm install --force
+            npm start

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  be-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH-deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{secrets.VPC_HOST}}
+          username: ${{secrets.VPC_USER}}
+          password: ${{secrets.VPC_PASSWORD}}
+          port: ${{secrets.VPC_PORT}}
+          script: |
+            whoami
+            cd /home/web08-ByeolSoop
+            git pull origin main
+            cd BE
+            npm install --force
+            npm run build
+            npm restart

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(process.env.BE_PORT);
 }
 bootstrap();


### PR DESCRIPTION
## 요약
- BE 배포 스크립트 작성
- FE 배포 스크립트 작성
- NCloud VPC에 정상적으로 동작하도록 구현

## 변경 사항

### BE 배포 스크립트 작성
- SSH로 직접 서버에 접속하여 프로젝트 폴더로 이동 후 pull하는 방식으로 배포했다.
- BE와 FE가 실행될 때 포트 번호를 다르게 해주어야 해서 BE의 포트 번호를 변경했다.
- BE 배포가 진행될 때 기존의 BE, FE 서버를 종료하기 위해 killall node를 수행한다.

### FE 배포 스크립트 작성
- BE와 동일하나 needs를 추가하여 BE 배포가 완료된 후에 배포하도록 설정했다.

### NCloud VPC에 정상적으로 동작하도록 구현
- NCloud VPC에 스크립트와 동일한 동작을 하여 서버에 제대로 접근이 되나 테스트했다.

## 참고 사항
- npm restart는 기존과 다른 터미널에서 실행 시 포트 겹침 문제가 있었다. 따라서 killall node를 통해 nodejs로 실행중인 프로세스를 모두 종료한 후 BE 실행 -> FE 실행 순으로 스크립트를 작성했다.

## 이슈 번호
close #50 

