### PR TITLE
[Hotfix] 배포 스크립트 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,39 +1,40 @@
 name: deploy
 
 on:
-  push:
-    branches:
-      - main
+    push:
+        branches:
+            - main
 jobs:
-  be-deploy:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: SSH-deploy
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{secrets.VPC_HOST}}
-          username: ${{secrets.VPC_USER}}
-          password: ${{secrets.VPC_PASSWORD}}
-          port: ${{secrets.VPC_PORT}}
-          script: |
-            cd /home/web08-ByeolSoop
-            git pull origin main
-            cd BE
-            npm install --force
-            killall node
-            npm start
-  fe-deploy:
-    needs: be-deploy
-    runs-on: ubuntu-20.04
-    steps:
-      - name: SSH-deploy
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{secrets.VPC_HOST}}
-          username: ${{secrets.VPC_USER}}
-          password: ${{secrets.VPC_PASSWORD}}
-          port: ${{secrets.VPC_PORT}}
-          script: |
-            cd /home/web08-ByeolSoop/FE
-            npm install --force
-            npm start
+    be-deploy:
+        runs-on: ubuntu-20.04
+        steps:
+            - name: SSH-deploy
+              uses: appleboy/ssh-action@master
+              with:
+                  host: ${{secrets.VPC_HOST}}
+                  username: ${{secrets.VPC_USER}}
+                  password: ${{secrets.VPC_PASSWORD}}
+                  port: ${{secrets.VPC_PORT}}
+                  script: |
+                      cd /home/web08-ByeolSoop
+                      git pull origin main
+                      cd BE
+                      npm install --force
+                      fuser -k ${{secrets.BE_PORT}}/tcp
+                      nohup npm run start </dev/null >/dev/null 2>&1 &
+    fe-deploy:
+        needs: be-deploy
+        runs-on: ubuntu-20.04
+        steps:
+            - name: SSH-deploy
+              uses: appleboy/ssh-action@master
+              with:
+                  host: ${{secrets.VPC_HOST}}
+                  username: ${{secrets.VPC_USER}}
+                  password: ${{secrets.VPC_PASSWORD}}
+                  port: ${{secrets.VPC_PORT}}
+                  script: |
+                      cd /home/web08-ByeolSoop/FE
+                      npm install --force
+                      fuser -k ${{secrets.FE_PORT}}/tcp
+                      nohup npm run start </dev/null >/dev/null 2>&1 &


### PR DESCRIPTION
## 요약

- 배포 스크립트 오류 수정

## 변경 사항

### 배포 스크립트 오류 수정
- 기존에는 npm start로 FE, BE 서버를 실행하도록 하였기 때문에 포어그라운드에서 두 서버가 모두 실행될 수 없어 오류가 발생했습니다.
- 현재는 nohup을 사용하여 백그라운드에서 두 서버가 실행되도록 하여 오류를 수정했습니다.
- 기존에는 killall node를 통해 동작중인 서버를 중지하도록 했지만 현재는 fuser -k를 사용하여 FE, BE 포트 각각에 대해서 중지하도록 만들었습니다.

## 참고 사항

- </dev/null은 입력을 받지 않도록, >/dev/null은 출력을 받지 않도록 하는 옵션입니다.
- 2>&1은 프로그램의 에러를 출력으로 받는 것이나, >/dev/null로 인해 무시됩니다.
- 마지막 &를 붙이면 해당 프로세스를 백그라운드에서 실행하도록 합니다. 

## 이슈 번호
close #59 
