### PR TITLE
[Feat] 타인의 일기 관련 기능에 대한 접근 막기

### DIFF
--- a/BE/src/auth/auth.id-guard.ts
+++ b/BE/src/auth/auth.id-guard.ts
@@ -1,0 +1,73 @@
+// import {
+//   ExecutionContext,
+//   Injectable,
+//   UnauthorizedException,
+// } from "@nestjs/common";
+// import { AuthGuard } from "@nestjs/passport";
+// import { DiariesRepository } from "src/diaries/diaries.repository";
+
+// @Injectable()
+// export class IdGuard extends AuthGuard("jwt") {
+//   constructor(private readonly diariesRepository: DiariesRepository) {
+//     super();
+//   }
+
+//   async handleRequest(err, user, info, context: ExecutionContext) {
+//     if (err || !user) {
+//       throw err || new UnauthorizedException();
+//     }
+
+//     const request = context.switchToHttp().getRequest();
+//     const requestDiary = await this.diariesRepository.getDiaryByUuid(
+//       request.params.uuid,
+//     );
+//     const requestUserId = requestDiary.user.userId;
+
+//     if (user.userId === requestUserId) {
+//       return user;
+//     } else {
+//       throw new UnauthorizedException();
+//     }
+//   }
+// }
+
+import {
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { DiariesRepository } from "src/diaries/diaries.repository";
+
+@Injectable()
+export class IdGuard extends AuthGuard("jwt") {
+  constructor(private readonly diariesRepository: DiariesRepository) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const result = (await super.canActivate(context)) as boolean;
+    if (!result) {
+      return false;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    // GET, DELETE 요청인 경우 params.uuid를 사용
+    // PUT 요청인 경우 body.uuid를 사용
+    const requestUuid = request.params.uuid
+      ? request.params.uuid
+      : request.body.uuid;
+    const requestDiary =
+      await this.diariesRepository.getDiaryByUuid(requestUuid);
+
+    if (this.getUserId(request.user) === requestDiary.user.userId) {
+      return true;
+    } else {
+      throw new UnauthorizedException();
+    }
+  }
+
+  private getUserId(user: any): string {
+    return user.userId;
+  }
+}

--- a/BE/src/auth/auth.id-guard.ts
+++ b/BE/src/auth/auth.id-guard.ts
@@ -1,36 +1,3 @@
-// import {
-//   ExecutionContext,
-//   Injectable,
-//   UnauthorizedException,
-// } from "@nestjs/common";
-// import { AuthGuard } from "@nestjs/passport";
-// import { DiariesRepository } from "src/diaries/diaries.repository";
-
-// @Injectable()
-// export class IdGuard extends AuthGuard("jwt") {
-//   constructor(private readonly diariesRepository: DiariesRepository) {
-//     super();
-//   }
-
-//   async handleRequest(err, user, info, context: ExecutionContext) {
-//     if (err || !user) {
-//       throw err || new UnauthorizedException();
-//     }
-
-//     const request = context.switchToHttp().getRequest();
-//     const requestDiary = await this.diariesRepository.getDiaryByUuid(
-//       request.params.uuid,
-//     );
-//     const requestUserId = requestDiary.user.userId;
-
-//     if (user.userId === requestUserId) {
-//       return user;
-//     } else {
-//       throw new UnauthorizedException();
-//     }
-//   }
-// }
-
 import {
   ExecutionContext,
   Injectable,

--- a/BE/src/auth/auth.id-guard.ts
+++ b/BE/src/auth/auth.id-guard.ts
@@ -1,7 +1,7 @@
 import {
   ExecutionContext,
   Injectable,
-  UnauthorizedException,
+  NotFoundException,
 } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { DiariesRepository } from "src/diaries/diaries.repository";
@@ -30,7 +30,7 @@ export class IdGuard extends AuthGuard("jwt") {
     if (this.getUserId(request.user) === requestDiary.user.userId) {
       return true;
     } else {
-      throw new UnauthorizedException();
+      throw new NotFoundException();
     }
   }
 

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { JwtStrategy } from "./jwt.strategy";
 import { UsersModule } from "src/users/users.module";
+import { IdGuard } from "./auth.id-guard";
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { UsersModule } from "src/users/users.module";
     UsersModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, IdGuard],
   exports: [PassportModule],
 })
 export class AuthModule {}

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -17,6 +17,7 @@ import {
 } from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 import { AuthGuard } from "@nestjs/passport";
+import { IdGuard } from "src/auth/auth.id-guard";
 
 @Controller("diaries")
 @UseGuards(AuthGuard())
@@ -29,6 +30,7 @@ export class DiariesController {
   }
 
   @Get("/:uuid")
+  @UseGuards(IdGuard)
   async readDiary(@Param("uuid") uuid: string): Promise<String> {
     const readDiaryDto: ReadDiaryDto = { uuid };
     const diary = await this.diariesService.readDiary(readDiaryDto);
@@ -57,11 +59,13 @@ export class DiariesController {
   }
 
   @Put()
+  @UseGuards(IdGuard)
   modifyDiary(@Body() updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
     return this.diariesService.modifyDiary(updateDiaryDto);
   }
 
   @Delete("/:uuid")
+  @UseGuards(IdGuard)
   deleteBoard(@Param("uuid") uuid: string): Promise<void> {
     const deleteDiaryDto: DeleteDiaryDto = { uuid };
     return this.diariesService.deleteDiary(deleteDiaryDto);

--- a/BE/src/diaries/diaries.entity.ts
+++ b/BE/src/diaries/diaries.entity.ts
@@ -22,10 +22,13 @@ export class Diary extends BaseEntity {
   @Generated("uuid")
   uuid: string;
 
-  @ManyToOne(() => User, (user) => user.userId, { nullable: false })
+  @ManyToOne(() => User, (user) => user.userId, {
+    nullable: false,
+    eager: true,
+  })
   user: User;
 
-  @ManyToOne(() => Shape, (shape) => shape.id, { nullable: false })
+  @ManyToOne(() => Shape, (shape) => shape.id, { nullable: false, eager: true })
   shape: Shape;
 
   @Column()


### PR DESCRIPTION
## 요약

- 타인의 일기에 대한 접근을 막는 IdGuard 구현
- 일기 API에 IdGuard 적용

## 변경 사항

### 타인의 일기에 대한 접근을 막는 IdGuard 구현
- 현재 요청한 유저의 userId값과 요청한 일기의 user.userId값이 일치하는지 확인하여 접근을 허용합니다.
- GET과 DELETE의 경우 url 파라미터로, PUT의 경우 body에 담아서 userId를 전달하기 때문에 삼항 연산자를 통해 상황에 맞게 적용될 수 있도록 만들었습니다.

![일기정상접근시](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/f76936ef-e723-45ad-b024-4e675cf499d3)

- 자신이 작성한 일기에 정상적으로 접근 시 올바른 값을 리턴합니다.

![일기비정상접근시](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/e08061fa-3b78-47e1-b6e4-946995f2949f)

- 타인의 일기에 접근 시 404 Not Found 에러를 응답합니다. 

### 일기 API에 IdGuard 적용
- 일기 API 중 타인의 접근을 막아야 하는 Read, Update, Delete에 대해 IdGuard 적용
- 일기 Create의 경우 타인의 userId로 생성이 불가능하기 때문에 비로그인 상태 접근만 막으면 됨

## 참고 사항

- diary.dto.ts에서 ManyToOne 관계를 맺고 있는 user, shape에게 eager: true 옵션을 넣었습니다. 
  - eager 옵션은 외래 키 관계를 맺은 해당 테이블을 eager loading하여 find 등의 메서드를 사용할 때 이 칼럼도 같이 join 시켜서 리턴하는 역할을 하게 됩니다. 

## 이슈 번호
close #62 
