### PR TITLE
[Feat] 태그 기능 구현

### DIFF
--- a/BE/src/diaries/diaries.dto.ts
+++ b/BE/src/diaries/diaries.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsDate, Matches, IsUUID } from "class-validator";
+import { IsString, IsDate, Matches, IsUUID, IsArray } from "class-validator";
 
 export class CreateDiaryDto {
   @IsString()
@@ -15,6 +15,9 @@ export class CreateDiaryDto {
 
   @IsDate()
   date: Date;
+
+  @IsArray()
+  tags: string[];
 }
 
 export class ReadDiaryDto {

--- a/BE/src/diaries/diaries.entity.ts
+++ b/BE/src/diaries/diaries.entity.ts
@@ -8,10 +8,13 @@ import {
   BaseEntity,
   ManyToOne,
   Generated,
+  ManyToMany,
+  JoinTable,
 } from "typeorm";
 import { User } from "src/users/users.entity";
 import { Shape } from "src/shapes/shapes.entity";
 import { sentimentStatus } from "src/utils/enum";
+import { Tag } from "src/tags/tags.entity";
 
 @Entity()
 export class Diary extends BaseEntity {
@@ -30,6 +33,10 @@ export class Diary extends BaseEntity {
 
   @ManyToOne(() => Shape, (shape) => shape.id, { nullable: false, eager: true })
   shape: Shape;
+
+  @ManyToMany(() => Tag, { eager: true })
+  @JoinTable()
+  tags: Tag[];
 
   @Column()
   title: string;

--- a/BE/src/diaries/diaries.entity.ts
+++ b/BE/src/diaries/diaries.entity.ts
@@ -34,7 +34,7 @@ export class Diary extends BaseEntity {
   @ManyToOne(() => Shape, (shape) => shape.id, { nullable: false, eager: true })
   shape: Shape;
 
-  @ManyToMany(() => Tag, { eager: true })
+  @ManyToMany(() => Tag, { eager: true, nullable: true })
   @JoinTable()
   tags: Tag[];
 

--- a/BE/src/diaries/diaries.module.ts
+++ b/BE/src/diaries/diaries.module.ts
@@ -5,9 +5,10 @@ import { DiariesService } from "./diaries.service";
 import { DiariesRepository } from "./diaries.repository";
 import { Diary } from "./diaries.entity";
 import { AuthModule } from "src/auth/auth.module";
+import { TagsModule } from "src/tags/tags.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Diary]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Diary]), AuthModule, TagsModule],
   controllers: [DiariesController],
   providers: [DiariesService, DiariesRepository],
 })

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -9,11 +9,13 @@ import { Diary } from "./diaries.entity";
 import { sentimentStatus } from "src/utils/enum";
 import { Shape } from "src/shapes/shapes.entity";
 import { NotFoundException } from "@nestjs/common";
+import { Tag } from "src/tags/tags.entity";
 
 export class DiariesRepository {
   async createDiary(
     createDiaryDto: CreateDiaryDto,
     encodedContent: string,
+    tag: Tag,
   ): Promise<Diary> {
     const { title, point, date } = createDiaryDto;
     const content = encodedContent;
@@ -39,6 +41,7 @@ export class DiariesRepository {
       sentiment,
       shape: { id: shape.id },
       user: { id: user.id },
+      tags: [tag],
     });
     await newDiary.save();
 

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -15,7 +15,7 @@ export class DiariesRepository {
   async createDiary(
     createDiaryDto: CreateDiaryDto,
     encodedContent: string,
-    tag: Tag,
+    tags: Tag[],
   ): Promise<Diary> {
     const { title, point, date } = createDiaryDto;
     const content = encodedContent;
@@ -41,7 +41,7 @@ export class DiariesRepository {
       sentiment,
       shape: { id: shape.id },
       user: { id: user.id },
-      tags: [tag],
+      tags: tags,
     });
     await newDiary.save();
 

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -8,6 +8,7 @@ import {
   UpdateDiaryDto,
 } from "./diaries.dto";
 import { TagsRepository } from "src/tags/tags.repository";
+import { Tag } from "src/tags/tags.entity";
 
 @Injectable()
 export class DiariesService {
@@ -19,12 +20,20 @@ export class DiariesService {
   async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary> {
     const encodedContent = btoa(createDiaryDto.content);
     // 추후 태그 입력 시 반복문으로 createTag를 돌려서 하나씩 Tag 생성
-    const tag = await this.tagsRepository.createTag("tagTest");
+    const tags = [];
+    createDiaryDto.tags.forEach(async (tag) => {
+      if ((await Tag.findOne({ where: { name: tag } })) !== null) {
+        const tagEntity = await Tag.findOneBy({ name: tag });
+        tags.push(tagEntity);
+      } else {
+        tags.push(await this.tagsRepository.createTag(tag));
+      }
+    });
 
     const diary = await this.diariesRepository.createDiary(
       createDiaryDto,
       encodedContent,
-      tag,
+      tags,
     );
 
     return diary;

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -7,14 +7,27 @@ import {
   ReadDiaryDto,
   UpdateDiaryDto,
 } from "./diaries.dto";
+import { TagsRepository } from "src/tags/tags.repository";
 
 @Injectable()
 export class DiariesService {
-  constructor(private diariesRepository: DiariesRepository) {}
+  constructor(
+    private diariesRepository: DiariesRepository,
+    private tagsRepository: TagsRepository,
+  ) {}
 
   async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary> {
     const encodedContent = btoa(createDiaryDto.content);
-    return this.diariesRepository.createDiary(createDiaryDto, encodedContent);
+    // 추후 태그 입력 시 반복문으로 createTag를 돌려서 하나씩 Tag 생성
+    const tag = await this.tagsRepository.createTag("tagTest");
+
+    const diary = await this.diariesRepository.createDiary(
+      createDiaryDto,
+      encodedContent,
+      tag,
+    );
+
+    return diary;
   }
 
   async readDiary(readDiaryDto: ReadDiaryDto): Promise<Diary> {

--- a/BE/src/tags/tags.controller.ts
+++ b/BE/src/tags/tags.controller.ts
@@ -1,0 +1,7 @@
+import { Controller, Get } from "@nestjs/common";
+import { TagsService } from "./tags.service";
+
+@Controller("tags")
+export class TagsController {
+  constructor(private tagsService: TagsService) {}
+}

--- a/BE/src/tags/tags.entity.ts
+++ b/BE/src/tags/tags.entity.ts
@@ -1,12 +1,4 @@
-import {
-  Entity,
-  PrimaryGeneratedColumn,
-  BaseEntity,
-  ManyToMany,
-  JoinTable,
-  Column,
-} from "typeorm";
-import { Diary } from "src/diaries/diaries.entity";
+import { Entity, PrimaryGeneratedColumn, BaseEntity, Column } from "typeorm";
 
 @Entity()
 export class Tag extends BaseEntity {
@@ -15,8 +7,4 @@ export class Tag extends BaseEntity {
 
   @Column()
   name: string;
-
-  @ManyToMany(() => Diary)
-  @JoinTable()
-  diaries: Diary[];
 }

--- a/BE/src/tags/tags.module.ts
+++ b/BE/src/tags/tags.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TagsController } from "./tags.controller";
+import { TagsService } from "./tags.service";
+import { TagsRepository } from "./tags.repository";
+import { Tag } from "./tags.entity";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tag])],
+  controllers: [TagsController],
+  providers: [TagsService, TagsRepository],
+  exports: [TagsRepository],
+})
+export class TagsModule {}

--- a/BE/src/tags/tags.repository.ts
+++ b/BE/src/tags/tags.repository.ts
@@ -1,0 +1,11 @@
+import { Diary } from "src/diaries/diaries.entity";
+import { Tag } from "./tags.entity";
+
+export class TagsRepository {
+  async createTag(name: string): Promise<Tag> {
+    const tag = await Tag.create({ name: name });
+    await tag.save();
+
+    return tag;
+  }
+}

--- a/BE/src/tags/tags.service.ts
+++ b/BE/src/tags/tags.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from "@nestjs/common";
+import { TagsRepository } from "./tags.repository";
+
+@Injectable()
+export class TagsService {
+  constructor(private tagsRepository: TagsRepository) {}
+}


### PR DESCRIPTION
## 요약

- 태그 기능을 위한 tags 디렉토리의 파일 구현
- ManyToMany 관계 설정 주체를 tags.entity에서 diaries.entity로 변경
- 일기 CREATE시 태그를 받아 저장하도록 추가

## 변경 사항

### 태그 기능을 위한 tags 디렉토리의 파일 구현
- 현재 사용하지 않는 tags.module, tags.controller, tags.service를 구현한 이유는 추후 일기 필터링 및 통계 기능을 위한 틀을 잡기 위함
- tags.repository에 태그 엔티티를 생성하여 저장하는 createTag 메서드 구현 

### ManyToMany 관계 설정 주체를 tags.entity에서 diaries.entity로 변경
- ManyToMany 관계 설정은 두 엔티티 중 더 중요하다고 생각되는 쪽에 붙여야 한다.
- 특히나 우리 서비스의 경우 Diary를 읽었을 때 그 안의 Tag까지 읽어와야 하기 때문에 Diary 쪽에 ManyToMany 관계 설정을 하도록 수정했다
  - 기존에는 Diary를 읽었을 때에는 어떤 Tag가 연결되었는지 보이지 않고, Tag를 읽으면 연결된 Diary가 보이는 구조였다.

### 일기 CREATE시 태그를 받아 저장하도록 추가
- createDiaryDto에 태그명을 전달받기 위한 string 타입 배열 tags를 추가
- diaries.service의 writeDiary에서 tags.repository를 import하여 tags에 있는 태그명을 통해 Tag 엔티티를 생성하여 배열에 저장한 후 diaries.repository에 넘겨줌
  - tags의 태그명을 기준으로 findOne을 통해 해당 태그가 존재하는지 확인한다. 
  - 태그가 이미 존재하는 경우 해당 태그를 findOneBy로 가져오고, 없는 경우에만 createTag를 통해 태그 엔티티를 생성한다

## 참고 사항

### 실행 결과
#### 일기 생성 성공 응답
![일기태그생성](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/00438ccf-97a5-426f-b932-4c36b1a46eb8)

#### 일기-태그 Join 테이블
![일기태그조인테이블](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/f8ba0ffe-ced2-4021-99dd-2863fa61254b)

## 이슈 번호
close #65 
