### PR TITLE
[Feat] 일기 목업 데이터 작성 및 연결

### DIFF
--- a/FE/public/data/data.json
+++ b/FE/public/data/data.json
@@ -1,0 +1,15 @@
+{
+  "userId": "관리자",
+  "title": "테스트 제목",
+  "content": "테스트 내용",
+  "date": "9999-99-99",
+  "tags": ["테스트1", "테스트2"],
+  "positive": 10,
+  "neutral": 50,
+  "negative": 40,
+  "sentiment": "중립",
+  "coordinate-x": 0,
+  "coordinate-y": 0,
+  "coordinate-z": 0,
+  "shapeUuid": "테스트 별모양 UUID"
+}

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useQuery } from "react-query";
 import styled from "styled-components";
 import { useRecoilState } from "recoil";
 import diaryAtom from "../../atoms/diaryAtom";
@@ -13,7 +14,7 @@ function DiaryModalEmotionIndicator({ emotion }) {
   return (
     <EmotionIndicatorWrapper>
       <EmotionIndicatorBar>
-        <EmotionIndicator ratio={emotion.positive} color='#618CF7' />
+        <EmotionIndicator ratio={`${emotion.positive}%`} color='#618CF7' />
         <EmotionIndicatorArrow>
           <img
             src={indicatorArrowIcon}
@@ -21,7 +22,7 @@ function DiaryModalEmotionIndicator({ emotion }) {
             style={{ width: "1rem", height: "1rem" }}
           />
         </EmotionIndicatorArrow>
-        <EmotionIndicator ratio={emotion.neutral} color='#A848F6' />
+        <EmotionIndicator ratio={`${emotion.neutral}%`} color='#A848F6' />
         <EmotionIndicatorArrow>
           <img
             src={indicatorArrowIcon}
@@ -29,24 +30,35 @@ function DiaryModalEmotionIndicator({ emotion }) {
             style={{ width: "1rem", height: "1rem" }}
           />
         </EmotionIndicatorArrow>
-        <EmotionIndicator ratio={emotion.negative} color='#E5575B' />
+        <EmotionIndicator ratio={`${emotion.negative}%`} color='#E5575B' />
       </EmotionIndicatorBar>
       <EmotionTextWrapper>
-        <EmotionText>긍정 {emotion.positive}</EmotionText>
-        <EmotionText>중립 {emotion.neutral}</EmotionText>
-        <EmotionText>부정 {emotion.negative}</EmotionText>
+        <EmotionText>긍정 {emotion.positive}%</EmotionText>
+        <EmotionText>중립 {emotion.neutral}%</EmotionText>
+        <EmotionText>부정 {emotion.negative}%</EmotionText>
       </EmotionTextWrapper>
     </EmotionIndicatorWrapper>
   );
 }
 
+async function getDiary() {
+  return fetch("http://localhost:3000/data/data.json").then((res) =>
+    res.json(),
+  );
+}
+
 function DiaryReadModal() {
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
+  const { data, isLoading, isError } = useQuery("diary", getDiary);
+
+  // TODO: 로딩, 에러 처리 UI 구현
+  if (isLoading) return <div>로딩중...</div>;
+  if (isError) return <div>에러가 발생했습니다</div>;
 
   return (
     <ModalWrapper left='67%' width='40vw' height='65vh' opacity='0.3'>
       <DiaryModalHeader>
-        <DiaryModalTitle>아주 멋진 나!</DiaryModalTitle>
+        <DiaryModalTitle>{data.title}</DiaryModalTitle>
         <DiaryButton>
           <img
             src={editIcon}
@@ -76,47 +88,21 @@ function DiaryReadModal() {
           />
         </DiaryButton>
       </DiaryModalHeader>
-      <DiaryModalContent>
-        오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다.
-        멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을
-        만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는
-        모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은
-        멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다!
-        오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다.
-        멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을
-        만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는
-        모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은
-        멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다!
-        오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다.
-        멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을
-        만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는
-        모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은
-        멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다!
-        오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다.
-        멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을
-        만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는
-        모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은
-        멋있는 모달을 만들었다. 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은
-        멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다!
-        오늘은 멋있는 모달을 만들었다. 오늘은 멋있는 모달을 만들었다. 멋있다!
-        오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다.
-        멋있다! 오늘은 멋있는 모달을 만들었다. 오늘은 멋있는 모달을 만들었다.
-        멋있다! 오늘은 멋있는 모달을 만들었다. 멋있다! 오늘은 멋있는 모달을
-        만들었다. 멋있다! 오늘은 멋있는 모달을 만들었다.
-      </DiaryModalContent>
+      <DiaryModalContent>{data.content}</DiaryModalContent>
       <DiaryModalTagBar>
         <DiaryModalTagName>태그</DiaryModalTagName>
         <DiaryModalTagList>
-          <DiaryModalTag>멋있다!</DiaryModalTag>
-          <DiaryModalTag>맛있다!</DiaryModalTag>
+          {data.tags.map((tag) => (
+            <DiaryModalTag>{tag}</DiaryModalTag>
+          ))}
         </DiaryModalTagList>
       </DiaryModalTagBar>
       <DiaryModalEmotionBar>
         <DiaryModalEmotionIndicator
           emotion={{
-            positive: "50%",
-            neutral: "20%",
-            negative: "30%",
+            positive: data.positive,
+            neutral: data.neutral,
+            negative: data.negative,
           }}
         />
         <DiaryModalIcon>

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -1,13 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { RecoilRoot } from "recoil";
 import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <RecoilRoot>
-      <App />
-    </RecoilRoot>
+    <QueryClientProvider client={new QueryClient()}>
+      <RecoilRoot>
+        <App />
+      </RecoilRoot>
+    </QueryClientProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## 요약

- 일기 읽기 모달에 대해 일기 목업 데이터 작성 및 연결

## 변경 사항

- public 폴더 내 일기 API 목업 데이터 작성
- 최상위 컴포넌트를 ueryClientProvider로 감싸줌
- 일기 읽기 모달 내에서 목업 데이터 연동

## 참고 사항

- 리액트 쿼리로 데이터를 받아올 때 로딩 및 에러 UI를 구현하면 어떨까?
- 리액트 hooks를 모두 컴포넌트 반환 전에 선언해야 한다.
    ```js
    if (isLoading) return <div>로딩중...</div>;
    if (isError) return <div>에러가 발생했습니다</div>;

    const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
    ```
    위와 같이 선언하면 에러가 발생한다. 따라서 다음과 같이 수정해야 함.

    ```js
    // 모든 hooks는 반환 전에 선언할 것
    const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
    const { data, isLoading, isError } = useQuery("diary", getDiary);

    if (isLoading) return <div>로딩중...</div>;
    if (isError) return <div>에러가 발생했습니다</div>;
    ```

## 이슈 번호

close #27 
