### PR TITLE
[Feat] 기본 모양 객체 응답 및 uuid에 해당하는 모양 스트림 반환 API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -5,6 +5,9 @@ import { UsersModule } from "./users/users.module";
 import { DiariesModule } from "./diaries/diaries.module";
 import { AuthModule } from "./auth/auth.module";
 import { IntroduceModule } from "./introduce/introduce.module";
+import { ShapesModule } from "./shapes/shapes.module";
+import { ShapesRepository } from "./shapes/shapes.repository";
+import { UsersRepository } from "./users/users.repository";
 
 @Module({
   imports: [
@@ -13,6 +16,25 @@ import { IntroduceModule } from "./introduce/introduce.module";
     DiariesModule,
     AuthModule,
     IntroduceModule,
+    ShapesModule,
   ],
+  providers: [ShapesRepository, UsersRepository],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(
+    private shapesRepository: ShapesRepository,
+    private usersRepository: UsersRepository,
+  ) {}
+
+  async onModuleInit() {
+    const commonUser =
+      (await this.usersRepository.getUserByUserId("commonUser")) ||
+      (await this.usersRepository.createUser({
+        userId: "commonUser",
+        password: process.env.COMMON_USER_PASS,
+        nickname: "commonUser",
+      }));
+
+    await this.shapesRepository.createDefaultShapes(commonUser);
+  }
+}

--- a/BE/src/auth/get-user.decorator.ts
+++ b/BE/src/auth/get-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { User } from "src/users/users.entity";
+
+export const GetUser = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext): User => {
+    const req = ctx.switchToHttp().getRequest();
+    return req.user;
+  },
+);

--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Get, Param, UseGuards } from "@nestjs/common";
 import { ShapesService } from "./shapes.service";
 import { AuthGuard } from "@nestjs/passport";
-import { IdGuard } from "src/auth/auth.id-guard";
 import { Shape } from "./shapes.entity";
+import { GetUser } from "src/auth/get-user.decorator";
+import { User } from "src/users/users.entity";
 
 @Controller("shapes")
 export class ShapesController {
@@ -14,8 +15,11 @@ export class ShapesController {
   }
 
   @Get("/:uuid")
-  @UseGuards(AuthGuard(), IdGuard)
-  async getShapeFilesByUuid(@Param("uuid") uuid: string): Promise<object> {
-    return this.shapesService.getShapeFileByUuid(uuid);
+  @UseGuards(AuthGuard())
+  async getShapeFilesByUuid(
+    @Param("uuid") uuid: string,
+    @GetUser() user: User,
+  ): Promise<object> {
+    return this.shapesService.getShapeFileByUuid(uuid, user);
   }
 }

--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Param, UseGuards } from "@nestjs/common";
+import { ShapesService } from "./shapes.service";
+import { AuthGuard } from "@nestjs/passport";
+import { IdGuard } from "src/auth/auth.id-guard";
+import { Shape } from "./shapes.entity";
+
+@Controller("shapes")
+export class ShapesController {
+  constructor(private shapesService: ShapesService) {}
+
+  @Get("/default")
+  async getDefaultShapeFiles(): Promise<Shape[]> {
+    return this.shapesService.getDefaultShapeFiles();
+  }
+
+  @Get("/:uuid")
+  @UseGuards(AuthGuard(), IdGuard)
+  async getShapeFilesByUuid(@Param("uuid") uuid: string): Promise<object> {
+    return this.shapesService.getShapeFileByUuid(uuid);
+  }
+}

--- a/BE/src/shapes/shapes.default.ts
+++ b/BE/src/shapes/shapes.default.ts
@@ -1,0 +1,7 @@
+import { Shape } from "./shapes.entity";
+
+export const defaultShapes: Partial<Shape>[] = [
+  { shapePath: "test-basic-shape-1.png" },
+  { shapePath: "test-basic-shape-2.png" },
+  { shapePath: "test-basic-shape-3.png" },
+];

--- a/BE/src/shapes/shapes.entity.ts
+++ b/BE/src/shapes/shapes.entity.ts
@@ -20,7 +20,7 @@ export class Shape extends BaseEntity {
   uuid: string;
 
   @ManyToOne(() => User, (user) => user.userId, { nullable: false })
-  user: User;
+  user: Promise<User>;
 
   @Column()
   shapePath: string;

--- a/BE/src/shapes/shapes.module.ts
+++ b/BE/src/shapes/shapes.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { UsersModule } from "src/users/users.module";
+import { Shape } from "./shapes.entity";
+import { ShapesController } from "./shapes.controller";
+import { ShapesService } from "./shapes.service";
+import { ShapesRepository } from "./shapes.repository";
+import { AuthModule } from "src/auth/auth.module";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Shape]), UsersModule, AuthModule],
+  controllers: [ShapesController],
+  providers: [ShapesService, ShapesRepository],
+})
+export class ShapesModule {}

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -12,7 +12,7 @@ export class ShapesRepository {
         );
 
         if (!existingShape) {
-          defaultShape.user = commonUser;
+          defaultShape.user = Promise.resolve(commonUser);
           const shape = Shape.create(defaultShape);
           await shape.save();
         }

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -1,0 +1,34 @@
+import { defaultShapes } from "./shapes.default";
+import { User } from "src/users/users.entity";
+import { Shape } from "./shapes.entity";
+import { NotFoundException } from "@nestjs/common";
+
+export class ShapesRepository {
+  async createDefaultShapes(commonUser: User) {
+    await Promise.all(
+      defaultShapes.map(async (defaultShape) => {
+        const existingShape = await this.getShapeByShapePath(
+          defaultShape.shapePath,
+        );
+
+        if (!existingShape) {
+          defaultShape.user = commonUser;
+          const shape = Shape.create(defaultShape);
+          await shape.save();
+        }
+      }),
+    );
+  }
+
+  async getShapeByShapePath(shapePath: string): Promise<Shape | null> {
+    return Shape.findOne({ where: { shapePath } });
+  }
+
+  async getShapeByUuid(uuid: string): Promise<Shape> {
+    const found = await Shape.findOne({ where: { uuid } });
+    if (!found) {
+      throw new NotFoundException(`Can't find Shape with uuid: [${uuid}]`);
+    }
+    return found;
+  }
+}

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -11,11 +11,11 @@ export class ShapesRepository {
           defaultShape.shapePath,
         );
 
-        if (!existingShape) {
-          defaultShape.user = Promise.resolve(commonUser);
-          const shape = Shape.create(defaultShape);
-          await shape.save();
-        }
+        if (existingShape) return;
+
+        defaultShape.user = Promise.resolve(commonUser);
+        const shape = Shape.create(defaultShape);
+        await shape.save();
       }),
     );
   }

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -20,9 +20,9 @@ export class ShapesService {
 
   async getShapeFileByUuid(uuid: string, user: User): Promise<object> {
     const shape = await this.shapesRepository.getShapeByUuid(uuid);
-    const shapeUser = await shape.user;
+    const { userId, id } = await shape.user;
 
-    if (shapeUser.userId !== "commonUser" && shapeUser.id !== user.id) {
+    if (userId !== "commonUser" && id !== user.id) {
       throw new UnauthorizedException();
     }
     return getFileFromS3(shape.shapePath);

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from "@nestjs/common";
+import { ShapesRepository } from "./shapes.repository";
+import { getFileFromS3 } from "src/utils/e3";
+import { defaultShapes } from "./shapes.default";
+import { Shape } from "./shapes.entity";
+
+@Injectable()
+export class ShapesService {
+  constructor(private shapesRepository: ShapesRepository) {}
+
+  async getDefaultShapeFiles(): Promise<Shape[]> {
+    const promises = defaultShapes.map(async (defaultShape) => {
+      return this.shapesRepository.getShapeByShapePath(defaultShape.shapePath);
+    });
+
+    const shapeFiles = await Promise.all(promises);
+    return shapeFiles;
+  }
+
+  async getShapeFileByUuid(uuid: string): Promise<object> {
+    const shape = await this.shapesRepository.getShapeByUuid(uuid);
+    return getFileFromS3(shape.shapePath);
+  }
+}

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -1,8 +1,9 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ShapesRepository } from "./shapes.repository";
 import { getFileFromS3 } from "src/utils/e3";
 import { defaultShapes } from "./shapes.default";
 import { Shape } from "./shapes.entity";
+import { User } from "src/users/users.entity";
 
 @Injectable()
 export class ShapesService {
@@ -17,8 +18,12 @@ export class ShapesService {
     return shapeFiles;
   }
 
-  async getShapeFileByUuid(uuid: string): Promise<object> {
+  async getShapeFileByUuid(uuid: string, user: User): Promise<object> {
     const shape = await this.shapesRepository.getShapeByUuid(uuid);
+
+    if ((await shape.user).id !== user.id) {
+      throw new UnauthorizedException();
+    }
     return getFileFromS3(shape.shapePath);
   }
 }

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -20,8 +20,9 @@ export class ShapesService {
 
   async getShapeFileByUuid(uuid: string, user: User): Promise<object> {
     const shape = await this.shapesRepository.getShapeByUuid(uuid);
+    const shapeUser = await shape.user;
 
-    if ((await shape.user).id !== user.id) {
+    if (shapeUser.userId !== "commonUser" && shapeUser.id !== user.id) {
       throw new UnauthorizedException();
     }
     return getFileFromS3(shape.shapePath);


### PR DESCRIPTION
## 요약

- `/shapes/default` GET 요청 처리 시 해당하는 Shape 객체 배열 반환
- `/shapes/:uuid` GET 요청 처리 시 해당하는 모양 스트림 반환
- `GetUser` 데코레이터 추가

## 변경 사항

### /shapes/default GET 요청 처리 시 해당하는 Shape 객체 배열 반환

- 이전에 PR #57 에서 생성해주신 NCP Object Storage 버킷에 테스트 모양 이미지 3개 저장
  - Content-Type을 `image/png`로 지정 
- 백엔드 서버를 실행시킬 때마다 Shape 테이블에 기본 모양에 대한 데이터 저장 
  - `AppModule`에서 `commonUser` 생성 후 User 정보로 추가
  - 기본 모양 데이터를 Shape 테이블에 추가
  - 이미 유저가 있거나, 모양 데이터 파일이 있다면 생성하지 않음
- `shapes.controller`에서 `shapes/default` GET 요청을 받아 해당하는 Shape 객체 배열 반환
  - 로그인 상태(인증)와 상관없이 결과를 반환

**[ shapes/default GET 요청 실행 결과 ]**
<img width="300" alt="스크린샷 2023-11-21 오전 12 16 17" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/cd5f1ffe-ca88-4a6a-ba47-698f6f746a83">


### /shapes/:uuid GET 요청 처리 시 해당하는 모양 스트림 반환
> Entities in lazy relations are loaded once you access them. Such relations must have Promise as type - you store your value in a promise, and when you load them a promise is returned as well.
> Lazy relations:  https://typeorm.io/eager-and-lazy-relations

- Shape Entity의 user 컬럼에 대해 **Lazy relations** 적용
  - Eager relations 과 달리 해당 데이터에 접근할 때 로드됨
  - 따라서 `Promise`으로 저장하고 `await`으로 데이터를 받아와야 함
  - 보통 Diary Entity에서 shape를 접근하기 때문에 Eager 보다는 Lazy relations 으로 선택
  - Shape Entity가 User 정보를 사용하는 경우는 권한에 대한 검사밖에 없기 때문에 필요하면 await으로 불러오는 것으로 선택
- `/shapes/:uuid` 요청에 대한 유저 권한 확인
  - **로그인한 상태**로 기본 모양에 대한 uuid를 포함하여 API 호출 시 유저 상관없이 반환
  - GetUser 데코레이터를 활용하여 해당하는 유저의 데이터인지 확인하는 조건문 추가
    - 성공 시 해당하는 모양 스트림 반환
    - 실패 시 `401 Unauthorized`

**[ shapes/:uuid GET 요청 성공 시 실행 결과 ]**
<img width="500" alt="스크린샷 2023-11-21 오전 12 26 12" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/11ab4a7c-b9ba-42be-a212-8169b2c6e14f">

### GetUser 데코레이터 추가 
- 요청으로부터 사용자 정보를 가져오는 GetUser 데코레이터 추가
- 위의 `shapes/:uuid` 요청 처리 시 User 정보를 가져오기 위해 구현
- `createDiary` 부분에도 사용되어야 하기 때문에 데코레이터로 구현


## 참고 사항

- 테이블 생성 시 모양 데이터 기본값 저장 구현시 참고한 사이트 : [[TypeORM] 테이블 생성시 기본값 저장 구현](https://iamiet.tistory.com/entry/Typeorm-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%83%9D%EC%84%B1%EC%8B%9C-%EA%B8%B0%EB%B3%B8%EA%B0%92-%EC%A0%80%EC%9E%A5-%EA%B5%AC%ED%98%84)
- 테스트 코드 작성 필요

**[Fix!]**
- 일기를 생성(Create)할 때 현재 구현된 Shape에 대한 정보가 `CreateDiaryDto`에 포함되어야 함
  - 태그 및 유저 정보도 함께 저장 필요
- 현재 스트림을 반환하는 getFileFromS3 함수를 사용하고 있는데, 스트림을 반환해주어도 서버가 다른 프론트에서는 데이터를 읽어올 수 없어서 백엔드에서 데이터를 직접 보내주도록 수정 필요

## 이슈 번호

- #67 
- close #64
