### PR TITLE
[Refactor] 사용자와 일기에 대한 엔티티, DTO 업데이트

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -33,7 +33,7 @@ export class AppModule {
         userId: "commonUser",
         password: process.env.COMMON_USER_PASS,
         nickname: "commonUser",
-        email: "commonuser@email.com",
+        email: "byeolsoop08@naver.com",
       }));
 
     await this.shapesRepository.createDefaultShapes(commonUser);

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -33,6 +33,7 @@ export class AppModule {
         userId: "commonUser",
         password: process.env.COMMON_USER_PASS,
         nickname: "commonUser",
+        email: "commonuser@email.com",
       }));
 
     await this.shapesRepository.createDefaultShapes(commonUser);

--- a/BE/src/configs/typeorm.config.ts
+++ b/BE/src/configs/typeorm.config.ts
@@ -9,7 +9,7 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   password: process.env.DB_PASS,
   database: process.env.DB_NAME,
   entities: ["dist/**/*.entity{.ts,.js}"],
-  synchronize: true,
+  synchronize: false,
   timezone: "+09:00",
 };
 
@@ -19,7 +19,7 @@ export const typeORMTestConfig: TypeOrmModuleOptions = {
   port: 3306,
   username: process.env.DB_USER,
   password: process.env.DB_PASS,
-  database: process.env.DB_NAME,
+  database: process.env.TEST_DB_NAME,
   entities: ["src/**/*.entity{.ts,.js}"],
   synchronize: true,
   timezone: "+09:00",

--- a/BE/src/diaries/diaries.dto.ts
+++ b/BE/src/diaries/diaries.dto.ts
@@ -18,6 +18,9 @@ export class CreateDiaryDto {
 
   @IsArray()
   tags: string[];
+
+  @IsUUID()
+  shapeUuid: string;
 }
 
 export class ReadDiaryDto {
@@ -35,10 +38,19 @@ export class UpdateDiaryDto {
   @IsString()
   content: string;
 
+  @IsString()
+  @Matches(RegExp("^-?d+(.d+)?,-?d+(.d+)?,-?d+(.d+)?$"), {
+    message: "적절하지 않은 포인트 양식입니다",
+  })
+  point: string;
+
   @IsDate()
   date: Date;
 
-  @IsString()
+  @IsArray()
+  tags: string[];
+
+  @IsUUID()
   shapeUuid: string;
 }
 

--- a/BE/src/diaries/diaries.entity.ts
+++ b/BE/src/diaries/diaries.entity.ts
@@ -44,9 +44,6 @@ export class Diary extends BaseEntity {
   @Column({ type: "text" })
   content: string;
 
-  @Column({ length: 7 })
-  color: string;
-
   @Column({ type: "float" })
   positiveRatio: number;
 

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -21,7 +21,6 @@ export class DiariesRepository {
     const content = encodedContent;
 
     // 미구현 기능을 대체하기 위한 임시 값
-    const color = "#FFFFFF";
     const positiveRatio = 0.0;
     const negativeRatio = 100.0;
     const neutralRatio = 0.0;
@@ -34,7 +33,6 @@ export class DiariesRepository {
       content,
       point,
       date,
-      color,
       positiveRatio,
       negativeRatio,
       neutralRatio,

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
   await app.listen(process.env.BE_PORT);
 }
 bootstrap();

--- a/BE/src/users/users.dto.ts
+++ b/BE/src/users/users.dto.ts
@@ -1,24 +1,29 @@
-import { IsString, IsNumber, IsEnum, MaxLength } from "class-validator";
-import { premiumStatus } from "src/utils/enum";
+import { IsString, Length, MaxLength, Matches } from "class-validator";
 
 export class CreateUserDto {
   @IsString()
-  @MaxLength(20)
+  @Length(4, 21)
   userId: string;
 
   @IsString()
-  @MaxLength(20)
+  @Matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}$")
+  email: string;
+
+  @IsString()
+  @Length(4, 21)
   password: string;
 
   @IsString()
-  @MaxLength(20)
+  @MaxLength(21)
   nickname: string;
 }
 
 export class LoginUserDto {
   @IsString()
+  @Length(4, 21)
   userId: string;
 
   @IsString()
+  @Length(4, 21)
   password: string;
 }

--- a/BE/src/users/users.entity.ts
+++ b/BE/src/users/users.entity.ts
@@ -20,6 +20,9 @@ export class User extends BaseEntity {
   @Column({ length: 20, unique: true })
   userId: string;
 
+  @Column({ unique: true })
+  email: string;
+
   @Column({ length: 60 })
   password: string;
 


### PR DESCRIPTION
## 요약

- 사용자 엔티티, DTO 업데이트
- 일기 엔티티, DTO 업데이트
- DB synchronize false로 수정
- CORS 정책 위반 오류 해결

## 변경 사항

### 사용자 엔티티, DTO 업데이트
- CreateUserDto, LoginUserDto에 Length를 적절하게 수정
- CreateuserDto에 email 추가. email을 위한 정규표현식 Matches도 작성 완료

### 일기 엔티티, DTO 업데이트
- CreateDiaryDto, UpdateDiaryDto에 shapeUuid 추가
- 일기 엔티티에 color 제거
- 수정 사항에 맞게 diaries.repository, app.module 업데이트

### DB synchronize false로 수정
- DB synchronize를 false로 하여 더 이상 구조 수정이 안되도록 변경

### CORS 정책 위반 오류 해결
- enableCors 함수를 통해 CORS 정책 허용

## 참고 사항

- 별숲 노션의 API 문서

## 이슈 번호
close #76 

