### PR TITLE
[Hotfix] 마스터 유저 생성 실패 오류 

### DIFF
--- a/BE/src/users/users.repository.ts
+++ b/BE/src/users/users.repository.ts
@@ -28,11 +28,7 @@ export class UsersRepository {
     return user;
   }
 
-  async getUserByUserId(userId: string): Promise<User> {
-    const found = await User.findOne({ where: { userId } });
-    if (!found) {
-      throw new NotFoundException(`Can't find User with UserId: [${userId}]`);
-    }
-    return found;
+  async getUserByUserId(userId: string): Promise<User | null> {
+    return User.findOne({ where: { userId } });
   }
 }


### PR DESCRIPTION

## 요약

### 마스터 유저 생성 실패 오류 수정
- getUserByUserId 처리 수정

## 변경 사항

- 아래와 같이 변경하여 app.module.ts 부분에서 유저가 없는 경우에 대한 처리가 잘 되도록 변경
```ts
async getUserByUserId(userId: string): Promise<User> {
    return found = await User.findOne({ where: { userId } });
}
```

## 참고 사항

## 이슈 번호

close #75
