### PR TITLE
[Feat] 스트림 파일에 대해서 StreamableFile 반환 기능 구현

### DIFF
--- a/BE/src/introduce/introduce.controller.ts
+++ b/BE/src/introduce/introduce.controller.ts
@@ -1,4 +1,9 @@
-import { Controller, Get } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  InternalServerErrorException,
+  StreamableFile,
+} from "@nestjs/common";
 import { IntroduceService } from "./introduce.service";
 
 @Controller("introduce")
@@ -6,7 +11,14 @@ export class IntroduceController {
   constructor(private introduceService: IntroduceService) {}
 
   @Get()
-  async getIntroduceVideo(): Promise<object> {
-    return this.introduceService.getIntroduceVideo();
+  async getIntroduceVideo(): Promise<StreamableFile> {
+    const stream = await this.introduceService.getIntroduceVideo();
+    try {
+      return new StreamableFile(stream);
+    } catch (error) {
+      throw new InternalServerErrorException(
+        "파일을 읽어오는 도중 서버에서 문제가 발생했습니다.",
+      );
+    }
   }
 }

--- a/BE/src/introduce/introduce.service.ts
+++ b/BE/src/introduce/introduce.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, StreamableFile } from "@nestjs/common";
 import { getFileFromS3 } from "src/utils/e3";
+import { Readable } from "stream";
 
 @Injectable()
 export class IntroduceService {
-  async getIntroduceVideo(): Promise<object> {
+  async getIntroduceVideo(): Promise<Readable> {
     return getFileFromS3("test.mp4");
   }
 }

--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, UseGuards } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  InternalServerErrorException,
+  Param,
+  StreamableFile,
+  UseGuards,
+} from "@nestjs/common";
 import { ShapesService } from "./shapes.service";
 import { AuthGuard } from "@nestjs/passport";
 import { Shape } from "./shapes.entity";
@@ -19,7 +26,14 @@ export class ShapesController {
   async getShapeFilesByUuid(
     @Param("uuid") uuid: string,
     @GetUser() user: User,
-  ): Promise<object> {
-    return this.shapesService.getShapeFileByUuid(uuid, user);
+  ): Promise<StreamableFile> {
+    const stream = await this.shapesService.getShapeFileByUuid(uuid, user);
+    try {
+      return new StreamableFile(stream);
+    } catch (error) {
+      throw new InternalServerErrorException(
+        "파일을 읽어오는 도중 서버에서 문제가 발생했습니다.",
+      );
+    }
   }
 }

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -4,6 +4,7 @@ import { getFileFromS3 } from "src/utils/e3";
 import { defaultShapes } from "./shapes.default";
 import { Shape } from "./shapes.entity";
 import { User } from "src/users/users.entity";
+import { Readable } from "stream";
 
 @Injectable()
 export class ShapesService {
@@ -18,7 +19,7 @@ export class ShapesService {
     return shapeFiles;
   }
 
-  async getShapeFileByUuid(uuid: string, user: User): Promise<object> {
+  async getShapeFileByUuid(uuid: string, user: User): Promise<Readable> {
     const shape = await this.shapesRepository.getShapeByUuid(uuid);
     const { userId, id } = await shape.user;
 

--- a/BE/src/utils/e3.ts
+++ b/BE/src/utils/e3.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { S3, Endpoint } from "aws-sdk";
-import { ReadStream, createReadStream } from "fs";
+import { Readable } from "stream";
 
 const endpoint = new Endpoint("https://kr.object.ncloudstorage.com");
 const region = "kr-standard";
@@ -16,8 +16,8 @@ const s3 = new S3({
   },
 });
 
-export async function getFileFromS3(fileName: string): Promise<object> {
-  const readStream = await s3
+export function getFileFromS3(fileName: string): Readable {
+  const readStream = s3
     .getObject({
       Bucket: "byeolsoop-bucket",
       Key: fileName,


### PR DESCRIPTION
## 요약

NCP Object Storage bucket에서 읽어온 스트림 파일에 대해 StreamableFile 반환 기능 구현


## 변경 사항

### 스트림 파일에 대해 StreamableFile 반환 기능 구현

> 참고: https://docs.nestjs.com/techniques/streaming-files

- StreamableFile은 반환될 스트림을 보유하는 클래스
- 데이터를 조각조각 나누어 전송할 수 있도록 도와준다.
  - 대용량 파일을 효율적으로 전송하도록 도와줌
- 파일 읽어오는 도중 문제 발생 시 500 Error code 반환
- `@Header("Content-Type", "image/png")` 와 같이 MIME 타입 지정
- StreamableFile, Readable로 반환 타입 설정

[ 실행 결과 ]

![image](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/5ed36c3a-2a92-43aa-b9bf-45c7ecfcf02a)


## 참고 사항

- FE 쪽에서 결과를 받아 blob() 을 사용하여 Blob 객체로 변환 후 사용해야 하는 것 같다.

## 이슈 번호

- close #67 

