### PR TITLE
[Feat] 일기 나열 페이지 UI 구현

### DIFF
--- a/FE/public/data/data.json
+++ b/FE/public/data/data.json
@@ -1,15 +1,32 @@
-{
-  "userId": "관리자",
-  "title": "테스트 제목",
-  "content": "테스트 내용",
-  "date": "9999-99-99",
-  "tags": ["테스트1", "테스트2"],
-  "positive": 10,
-  "neutral": 50,
-  "negative": 40,
-  "sentiment": "중립",
-  "coordinate-x": 0,
-  "coordinate-y": 0,
-  "coordinate-z": 0,
-  "shapeUuid": "테스트 별모양 UUID"
-}
+[
+  {
+    "userId": "관리자",
+    "title": "테스트 제목",
+    "content": "테스트 내용",
+    "date": "9999-99-99",
+    "tags": ["테스트1", "테스트2"],
+    "positive": 10,
+    "neutral": 50,
+    "negative": 40,
+    "sentiment": "중립",
+    "coordinate-x": 0,
+    "coordinate-y": 0,
+    "coordinate-z": 0,
+    "shapeUuid": "테스트 별모양 UUID"
+  },
+  {
+    "userId": "관리자",
+    "title": "테스트 제목2",
+    "content": "테스트 내용2",
+    "date": "9999-99-99",
+    "tags": ["테스트1", "테스트2"],
+    "positive": 10,
+    "neutral": 50,
+    "negative": 40,
+    "sentiment": "중립",
+    "coordinate-x": 0,
+    "coordinate-y": 0,
+    "coordinate-z": 0,
+    "shapeUuid": "테스트 별모양 UUID"
+  }
+]

--- a/FE/src/atoms/diaryAtom.js
+++ b/FE/src/atoms/diaryAtom.js
@@ -6,6 +6,7 @@ const diaryAtom = atom({
     isCreate: false,
     isRead: false,
     isDelete: false,
+    isList: false,
   },
 });
 

--- a/FE/src/atoms/headerAtom.js
+++ b/FE/src/atoms/headerAtom.js
@@ -5,6 +5,7 @@ const headerAtom = atom({
   default: {
     isLogin: false,
     isSignUp: false,
+    isSideBar: false,
   },
 });
 

--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -13,16 +13,25 @@ function DiaryDeleteModal() {
       <DeleteModalButtonWrapper>
         <DeleteModalButton
           onClick={() => {
-            setDiaryState({
-              isCreate: false,
-              isRead: true,
+            setDiaryState((prev) => ({
+              ...prev,
               isDelete: false,
-            });
+            }));
           }}
         >
           취소
         </DeleteModalButton>
-        <DeleteModalButton>확인</DeleteModalButton>
+        <DeleteModalButton
+          onClick={() => {
+            setDiaryState((prev) => ({
+              ...prev,
+              isRead: false,
+              isDelete: false,
+            }));
+          }}
+        >
+          확인
+        </DeleteModalButton>
       </DeleteModalButtonWrapper>
     </DeleteModalWrapper>
   );

--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -1,0 +1,161 @@
+import React, { useEffect } from "react";
+import { useQuery } from "react-query";
+import styled from "styled-components";
+
+function DiaryListModal() {
+  const [selectedDiary, setSelectedDiary] = React.useState(null);
+  const {
+    data: DiaryList,
+    // error,
+    isLoading,
+  } = useQuery("diaryList", () =>
+    fetch("http://localhost:3000/data/data.json").then((res) => res.json()),
+  );
+
+  useEffect(() => {
+    if (DiaryList) {
+      setSelectedDiary(DiaryList[0]);
+    }
+  }, [DiaryList]);
+
+  if (isLoading) return <div>로딩중...</div>;
+
+  return (
+    <DiaryListModalWrapper>
+      <DiaryListModalItem>
+        <DiaryListModalFilterWrapper>
+          <DiaryTitleListHeader>날짜</DiaryTitleListHeader>
+          <DiaryListModalFilterContent>필터</DiaryListModalFilterContent>
+        </DiaryListModalFilterWrapper>
+        <DiaryListModalFilterWrapper>
+          <DiaryTitleListHeader>감정</DiaryTitleListHeader>
+          <DiaryListModalFilterContent>필터</DiaryListModalFilterContent>
+        </DiaryListModalFilterWrapper>
+        <DiaryListModalFilterWrapper>
+          <DiaryTitleListHeader>모양</DiaryTitleListHeader>
+          <DiaryListModalFilterContent>필터</DiaryListModalFilterContent>
+        </DiaryListModalFilterWrapper>
+        <DiaryListModalFilterWrapper>
+          <DiaryTitleListHeader>태그</DiaryTitleListHeader>
+          <DiaryListModalFilterContent>필터</DiaryListModalFilterContent>
+        </DiaryListModalFilterWrapper>
+      </DiaryListModalItem>
+      <DiaryListModalItem>
+        <DiaryTitleListHeader>제목</DiaryTitleListHeader>
+        {DiaryList?.map((diary) => (
+          <DiaryTitleListItem
+            key={diary.id}
+            onClick={() => {
+              setSelectedDiary(diary);
+            }}
+          >
+            {diary.title}
+          </DiaryTitleListItem>
+        ))}
+      </DiaryListModalItem>
+      <DiaryListModalItem width='50%'>
+        <DiaryTitle>{selectedDiary?.title}</DiaryTitle>
+        <DiaryContent>{selectedDiary?.content}</DiaryContent>
+      </DiaryListModalItem>
+    </DiaryListModalWrapper>
+  );
+}
+
+const DiaryListModalWrapper = styled.div`
+  width: 95%;
+  height: 97.5%;
+  position: absolute;
+  top: 2.5%;
+  left: 2.5%;
+  z-index: 1001;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1%;
+`;
+
+const DiaryListModalItem = styled.div`
+  width: ${(props) => props.width || "25%"};
+  height: 85%;
+  background-color: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(10px);
+  border-radius: 1rem;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  font-size: 1.3rem;
+  color: #ffffff;
+`;
+
+const DiaryListModalFilterWrapper = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  font-size: 1.1rem;
+`;
+
+const DiaryListModalFilterContent = styled.div`
+  width: 100%;
+  height: 4.5rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const DiaryTitleListHeader = styled.div`
+  width: 100%;
+  height: 3.5rem;
+  padding-left: 3rem;
+
+  display: flex;
+  align-items: center;
+
+  font-size: 1.1rem;
+`;
+
+const DiaryTitleListItem = styled.div`
+  width: 100%;
+  height: 4.5rem;
+  border-top: 1px solid #ffffff;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+`;
+
+const DiaryTitle = styled.div`
+  width: 100%;
+  height: 4.5rem;
+  padding-left: 3rem;
+
+  display: flex;
+  align-items: center;
+
+  font-size: 1.3rem;
+`;
+
+const DiaryContent = styled.div`
+  width: 100%;
+  height: 4.5rem;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: 1.1rem;
+`;
+
+export default DiaryListModal;

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -71,11 +71,10 @@ function DiaryReadModal() {
         </DiaryButton>
         <DiaryButton
           onClick={() => {
-            setDiaryState({
-              isCreate: false,
-              isRead: true,
+            setDiaryState((prev) => ({
+              ...prev,
               isDelete: true,
-            });
+            }));
           }}
         >
           <img
@@ -88,11 +87,11 @@ function DiaryReadModal() {
           />
         </DiaryButton>
       </DiaryModalHeader>
-      <DiaryModalContent>{data.content}</DiaryModalContent>
+      <DiaryModalContent>{data[0].content}</DiaryModalContent>
       <DiaryModalTagBar>
         <DiaryModalTagName>태그</DiaryModalTagName>
         <DiaryModalTagList>
-          {data.tags.map((tag) => (
+          {data[0].tags.map((tag) => (
             <DiaryModalTag>{tag}</DiaryModalTag>
           ))}
         </DiaryModalTagList>
@@ -100,9 +99,9 @@ function DiaryReadModal() {
       <DiaryModalEmotionBar>
         <DiaryModalEmotionIndicator
           emotion={{
-            positive: data.positive,
-            neutral: data.neutral,
-            negative: data.negative,
+            positive: data[0].positive,
+            neutral: data[0].neutral,
+            negative: data[0].negative,
           }}
         />
         <DiaryModalIcon>

--- a/FE/src/components/Header/Header.js
+++ b/FE/src/components/Header/Header.js
@@ -25,20 +25,22 @@ function Header() {
           <LoginBar>
             <LoginItem
               onClick={() => {
-                setHeaderState({
+                setHeaderState((prev) => ({
+                  ...prev,
                   isLogin: false,
                   isSignUp: true,
-                });
+                }));
               }}
             >
               회원가입
             </LoginItem>
             <LoginItem
               onClick={() => {
-                setHeaderState({
+                setHeaderState((prev) => ({
+                  ...prev,
                   isLogin: true,
                   isSignUp: false,
-                });
+                }));
               }}
             >
               로그인
@@ -49,11 +51,10 @@ function Header() {
             src={sideBarImg}
             alt='side-bar'
             onClick={() => {
-              setHeaderState({
-                isLogin: false,
-                isSignUp: false,
+              setHeaderState((prev) => ({
+                ...prev,
                 isSideBar: !HeaderState.isSideBar,
-              });
+              }));
             }}
           />
         )}

--- a/FE/src/components/SideBar/SideBar.js
+++ b/FE/src/components/SideBar/SideBar.js
@@ -1,11 +1,13 @@
 import React from "react";
 import styled from "styled-components";
 import { useSetRecoilState } from "recoil";
+import diaryAtom from "../../atoms/diaryAtom";
 import headerAtom from "../../atoms/headerAtom";
 import userAtom from "../../atoms/userAtom";
 import boostcampImg from "../../assets/boostcamp.png";
 
 function SideBar() {
+  const setDiaryState = useSetRecoilState(diaryAtom);
   const setHeaderState = useSetRecoilState(headerAtom);
   const setUserState = useSetRecoilState(userAtom);
 
@@ -13,8 +15,34 @@ function SideBar() {
     <>
       <SideBarWrapper>
         <SideBarContentWrapper>
-          <SideBarContent>일기 쓰기</SideBarContent>
-          <SideBarContent>일기 목록</SideBarContent>
+          <SideBarContent
+            onClick={() => {
+              setHeaderState((prev) => ({
+                ...prev,
+                isSideBar: false,
+              }));
+              setDiaryState((prev) => ({
+                ...prev,
+                isList: false,
+              }));
+            }}
+          >
+            일기 쓰기
+          </SideBarContent>
+          <SideBarContent
+            onClick={() => {
+              setHeaderState((prev) => ({
+                ...prev,
+                isSideBar: false,
+              }));
+              setDiaryState((prev) => ({
+                ...prev,
+                isList: true,
+              }));
+            }}
+          >
+            일기 목록
+          </SideBarContent>
           <SideBarContent>일기 분석</SideBarContent>
           <SideBarContent>환경 설정</SideBarContent>
           <SideBarContent>별숲 상점</SideBarContent>

--- a/FE/src/components/SideBar/SideBar.js
+++ b/FE/src/components/SideBar/SideBar.js
@@ -35,10 +35,12 @@ function SideBar() {
                 ...prev,
                 isSideBar: false,
               }));
-              setDiaryState((prev) => ({
-                ...prev,
+              setDiaryState({
+                isCreate: false,
+                isRead: false,
+                isDelete: false,
                 isList: true,
-              }));
+              });
             }}
           >
             일기 목록

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -5,6 +5,7 @@ import diaryAtom from "../atoms/diaryAtom";
 import DiaryCreateModal from "../components/DiaryModal/DiaryCreateModal";
 import DiaryReadModal from "../components/DiaryModal/DiaryReadModal";
 import background from "../assets/background.png";
+import DiaryListModal from "../components/DiaryModal/DiaryListModal";
 
 function MainPage() {
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
@@ -14,17 +15,14 @@ function MainPage() {
       <MainPageWrapper
         onClick={(e) => {
           e.preventDefault();
-          setDiaryState({
-            isCreate: false,
-            isRead: true,
-            isDelete: false,
-          });
+          setDiaryState((prev) => ({ ...prev, isRead: true }));
         }}
       >
         <MainTitle>대충 메인 페이지</MainTitle>
       </MainPageWrapper>
       {diaryState.isCreate ? <DiaryCreateModal /> : null}
       {diaryState.isRead ? <DiaryReadModal /> : null}
+      {diaryState.isList ? <DiaryListModal /> : null}
     </>
   );
 }


### PR DESCRIPTION
## 요약

- 일기 나열 페이지 UI 구현
<img width="1665" alt="스크린샷 2023-11-22 오후 12 00 43" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/67178684/b73898d9-38e0-427f-a085-7dac9af96414">

## 변경 사항

- 목업 데이터를 일기 데이터 배열으로 변경
- 일기 나열 페이지 UI 구현
- Atom에 나열 페이지 상태 추가
- 나열 페이지 상태 수정 이벤트 추가
- prev를 활용한 상태 수정 이벤트 가독성 향상

## 참고 사항

- 추후 나열 페이지 필터 구현 필요

## 이슈 번호

close #87 
