### PR TITLE
[Fix] 일기 생성 시 태그 관련 동작에 비동기 처리 추가

### DIFF
--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -19,16 +19,18 @@ export class DiariesService {
 
   async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary> {
     const encodedContent = btoa(createDiaryDto.content);
-    // 추후 태그 입력 시 반복문으로 createTag를 돌려서 하나씩 Tag 생성
     const tags = [];
-    createDiaryDto.tags.forEach(async (tag) => {
-      if ((await Tag.findOne({ where: { name: tag } })) !== null) {
-        const tagEntity = await Tag.findOneBy({ name: tag });
-        tags.push(tagEntity);
-      } else {
-        tags.push(await this.tagsRepository.createTag(tag));
-      }
-    });
+
+    await Promise.all(
+      createDiaryDto.tags.map(async (tag) => {
+        if ((await Tag.findOne({ where: { name: tag } })) !== null) {
+          const tagEntity = await Tag.findOneBy({ name: tag });
+          tags.push(tagEntity);
+        } else {
+          tags.push(await this.tagsRepository.createTag(tag));
+        }
+      }),
+    );
 
     const diary = await this.diariesRepository.createDiary(
       createDiaryDto,


### PR DESCRIPTION
## 요약

- 일기 생성 시 태그 관련 동작에 비동기 처리 추가

## 변경 사항

### 일기 생성 시 태그 관련 동작에 비동기 처리 추가
- 일기를 생성하는 writeDiary에서 태그명을 받아 태그 객체를 생성하거나 불러오는 코드에 비동기 처리를 추가하여 태그가 누락되지 않도록 함

## 참고 사항

- forEach나 map 등의 경우 async / await으로 비동기 처리가 되지 않기 때문에 Promise.all()로 묶어 await을 붙이도록 수정함 

## 이슈 번호
close #93
