### PR TITLE
[Feat] 일기 나열 페이지 API 연동

### DIFF
--- a/FE/src/assets/zoomIn.svg
+++ b/FE/src/assets/zoomIn.svg
@@ -1,0 +1,4 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 14.3198V23.9998M2 23.9998H11.68M2 23.9998L10.5 15.4998" stroke="white" stroke-width="3"/>
+<path d="M24 11.6802L24 2.00018M24 2.00018L14.32 2.00018M24 2.00018L15.5 10.5002" stroke="white" stroke-width="3"/>
+</svg>

--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -1,18 +1,28 @@
-import React, { useEffect } from "react";
+import React, { useLayoutEffect } from "react";
 import { useQuery } from "react-query";
 import styled from "styled-components";
+import { useRecoilValue } from "recoil";
+import userAtom from "../../atoms/userAtom";
+import zoomIn from "../../assets/zoomIn.svg";
 
 function DiaryListModal() {
   const [selectedDiary, setSelectedDiary] = React.useState(null);
+  const userState = useRecoilValue(userAtom);
   const {
     data: DiaryList,
     // error,
     isLoading,
   } = useQuery("diaryList", () =>
-    fetch("http://localhost:3000/data/data.json").then((res) => res.json()),
+    fetch("http://223.130.129.145:3005/diaries", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userState.accessToken}`,
+      },
+    }).then((res) => res.json()),
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (DiaryList) {
       setSelectedDiary(DiaryList[0]);
     }
@@ -42,19 +52,28 @@ function DiaryListModal() {
       </DiaryListModalItem>
       <DiaryListModalItem>
         <DiaryTitleListHeader>제목</DiaryTitleListHeader>
-        {DiaryList?.map((diary) => (
-          <DiaryTitleListItem
-            key={diary.id}
-            onClick={() => {
-              setSelectedDiary(diary);
-            }}
-          >
-            {diary.title}
-          </DiaryTitleListItem>
-        ))}
+        <DiaryTitleListItemWrapper
+          onMouseEnter={(e) => {
+            e.target.focus();
+          }}
+        >
+          {DiaryList?.map((diary) => (
+            <DiaryTitleListItem
+              key={diary.id}
+              onClick={() => {
+                setSelectedDiary(diary);
+              }}
+            >
+              {diary.title}
+            </DiaryTitleListItem>
+          ))}
+        </DiaryTitleListItemWrapper>
       </DiaryListModalItem>
       <DiaryListModalItem width='50%'>
-        <DiaryTitle>{selectedDiary?.title}</DiaryTitle>
+        <DiaryTitle>
+          {selectedDiary?.title}
+          <DiaryTitleImg src={zoomIn} alt='zoom-in' />
+        </DiaryTitle>
         <DiaryContent>{selectedDiary?.content}</DiaryContent>
       </DiaryListModalItem>
     </DiaryListModalWrapper>
@@ -78,7 +97,7 @@ const DiaryListModalWrapper = styled.div`
 const DiaryListModalItem = styled.div`
   width: ${(props) => props.width || "25%"};
   height: 85%;
-  background-color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.3);
   backdrop-filter: blur(10px);
   border-radius: 1rem;
 
@@ -117,34 +136,60 @@ const DiaryTitleListHeader = styled.div`
   display: flex;
   align-items: center;
 
+  flex-shrink: 0;
+
   font-size: 1.1rem;
+`;
+
+const DiaryTitleListItemWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  overflow-y: scroll;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const DiaryTitleListItem = styled.div`
   width: 100%;
   height: 4.5rem;
-  border-top: 1px solid #ffffff;
+  border-top: 0.5px solid #ffffff;
 
   display: flex;
   justify-content: center;
   align-items: center;
 
+  flex-shrink: 0;
+
   cursor: pointer;
 
   &:hover {
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(255, 255, 255, 0.3);
   }
 `;
 
 const DiaryTitle = styled.div`
-  width: 100%;
-  height: 4.5rem;
-  padding-left: 3rem;
+  width: 85%;
+  height: 7rem;
 
   display: flex;
+  justify-content: space-between;
   align-items: center;
 
-  font-size: 1.3rem;
+  font-size: 1.5rem;
+`;
+
+const DiaryTitleImg = styled.img`
+  width: 1.3rem;
+  height: 1.3rem;
+
+  cursor: pointer;
 `;
 
 const DiaryContent = styled.div`

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -143,7 +143,7 @@ const DiaryButton = styled.button`
   border: hidden;
   background: none;
 
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.3);
   font-size: 1rem;
 
   gap: 0.5rem;
@@ -179,7 +179,7 @@ const DiaryModalTag = styled.div`
   width: 5rem;
   height: 2rem;
   border-radius: 1rem;
-  background-color: rgba(255, 255, 255, 0.4);
+  background-color: rgba(255, 255, 255, 0.3);
   padding: 0.5rem;
   box-sizing: border-box;
   color: #ffffff;

--- a/FE/src/styles/Modal/ModalWrapper.js
+++ b/FE/src/styles/Modal/ModalWrapper.js
@@ -12,7 +12,7 @@ const ModalWrapper = styled.div`
   z-index: 1001;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
-  background-color: rgba(255, 255, 255, ${(props) => props.opacity || 0.5});
+  background-color: rgba(255, 255, 255, ${(props) => props.opacity || 0.3});
   backdrop-filter: blur(10px);
   transform: translate(-50%, -50%);
   border-radius: 1rem;


### PR DESCRIPTION
## 요약

- 일기 나열 페이지 API 연동
<img width="1918" alt="스크린샷 2023-11-22 오후 3 32 05" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/67178684/130147ae-cf64-42a2-8fac-7634c61da365">


## 변경 사항

- 모든 모달에 대해 배경색 투명도 0.3으로 통일
- react-query 활용 일기 전체 조회 API 연동
- 일기 줌인 버튼 추가

## 참고 사항

- 추후 디자인 수정 필요

## 이슈 번호

close #95 
