### PR TITLE
[Feat] 일기 삭제 API에 대한 서버 응답 수정 및 e2e 테스트 작성

### DIFF
--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -6,7 +6,7 @@ import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { JwtStrategy } from "./jwt.strategy";
 import { UsersModule } from "src/users/users.module";
-import { IdGuard } from "./guard/auth.id-guard";
+import { PrivateDiaryGuard } from "./guard/auth.diary-guard";
 
 @Module({
   imports: [
@@ -20,7 +20,7 @@ import { IdGuard } from "./guard/auth.id-guard";
     UsersModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, IdGuard],
+  providers: [AuthService, JwtStrategy, PrivateDiaryGuard],
   exports: [PassportModule],
 })
 export class AuthModule {}

--- a/BE/src/auth/guard/auth.diary-guard.ts
+++ b/BE/src/auth/guard/auth.diary-guard.ts
@@ -7,7 +7,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { DiariesRepository } from "src/diaries/diaries.repository";
 
 @Injectable()
-export class IdGuard extends AuthGuard("jwt") {
+export class PrivateDiaryGuard extends AuthGuard("jwt") {
   constructor(private readonly diariesRepository: DiariesRepository) {
     super();
   }
@@ -30,7 +30,7 @@ export class IdGuard extends AuthGuard("jwt") {
     if (this.getUserId(request.user) === requestDiary.user.userId) {
       return true;
     } else {
-      throw new NotFoundException();
+      throw new NotFoundException("존재하지 않는 일기입니다.");
     }
   }
 

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -112,8 +112,10 @@ export class DiariesController {
 
   @Delete("/:uuid")
   @UseGuards(IdGuard)
-  deleteBoard(@Param("uuid") uuid: string): Promise<void> {
+  @HttpCode(204)
+  async deleteDiary(@Param("uuid") uuid: string): Promise<void> {
     const deleteDiaryDto: DeleteDiaryDto = { uuid };
-    return this.diariesService.deleteDiary(deleteDiaryDto);
+    await this.diariesService.deleteDiary(deleteDiaryDto);
+    return;
   }
 }

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -20,7 +20,7 @@ import {
 } from "./diaries.dto";
 import { Diary } from "./diaries.entity";
 import { AuthGuard } from "@nestjs/passport";
-import { IdGuard } from "src/auth/guard/auth.id-guard";
+import { PrivateDiaryGuard } from "src/auth/guard/auth.diary-guard";
 import { GetUser } from "src/auth/get-user.decorator";
 import { User } from "src/users/users.entity";
 
@@ -39,7 +39,7 @@ export class DiariesController {
   }
 
   @Get("/:uuid")
-  @UseGuards(IdGuard)
+  @UseGuards(PrivateDiaryGuard)
   async readDiary(@Param("uuid") uuid: string): Promise<Object> {
     const readDiaryDto: ReadDiaryDto = { uuid };
     const diary = await this.diariesService.readDiary(readDiaryDto);
@@ -105,13 +105,13 @@ export class DiariesController {
   }
 
   @Put()
-  @UseGuards(IdGuard)
+  @UseGuards(PrivateDiaryGuard)
   modifyDiary(@Body() updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
     return this.diariesService.modifyDiary(updateDiaryDto);
   }
 
   @Delete("/:uuid")
-  @UseGuards(IdGuard)
+  @UseGuards(PrivateDiaryGuard)
   @HttpCode(204)
   async deleteDiary(@Param("uuid") uuid: string): Promise<void> {
     const deleteDiaryDto: DeleteDiaryDto = { uuid };

--- a/BE/src/diaries/diaries.dto.ts
+++ b/BE/src/diaries/diaries.dto.ts
@@ -68,7 +68,7 @@ export class UpdateDiaryDto {
 }
 
 export class DeleteDiaryDto {
-  @IsUUID()
+  @IsUUID("4", { message: "일기 uuid 값이 uuid 양식이어야 합니다." })
   uuid: string;
 }
 

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -82,14 +82,15 @@ export class DiariesRepository {
   async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {
     const { uuid } = deleteDiaryDto;
     const diary = await this.getDiaryByUuid(uuid);
-    if (!diary) {
-      throw new Error();
-    }
 
     await Diary.softRemove(diary);
   }
 
   async getDiaryByUuid(uuid: string): Promise<Diary> {
-    return Diary.findOneBy({ uuid });
+    const found = await Diary.findOneBy({ uuid });
+    if (!found) {
+      throw new NotFoundException(`존재하지 않는 일기입니다.`);
+    }
+    return found;
   }
 }

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -82,15 +82,14 @@ export class DiariesRepository {
   async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {
     const { uuid } = deleteDiaryDto;
     const diary = await this.getDiaryByUuid(uuid);
+    if (!diary) {
+      throw new Error();
+    }
 
     await Diary.softRemove(diary);
   }
 
   async getDiaryByUuid(uuid: string): Promise<Diary> {
-    const found = await Diary.findOneBy({ uuid });
-    if (!found) {
-      throw new NotFoundException(`Can't find Diary with uuid: [${uuid}]`);
-    }
-    return found;
+    return Diary.findOneBy({ uuid });
   }
 }

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -68,11 +68,7 @@ export class DiariesService {
   }
 
   async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {
-    try {
-      await this.diariesRepository.deleteDiary(deleteDiaryDto);
-    } catch {
-      throw new NotFoundException("존재하지 않는 일기입니다.");
-    }
+    await this.diariesRepository.deleteDiary(deleteDiaryDto);
     return;
   }
 }

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { DiariesRepository } from "./diaries.repository";
 import { Diary } from "./diaries.entity";
 import {
@@ -68,6 +68,11 @@ export class DiariesService {
   }
 
   async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {
-    return this.diariesRepository.deleteDiary(deleteDiaryDto);
+    try {
+      await this.diariesRepository.deleteDiary(deleteDiaryDto);
+    } catch {
+      throw new NotFoundException("존재하지 않는 일기입니다.");
+    }
+    return;
   }
 }

--- a/BE/test/diaries.delete.e2e-spec.ts
+++ b/BE/test/diaries.delete.e2e-spec.ts
@@ -55,4 +55,14 @@ describe("AppController (e2e)", () => {
       .set("Authorization", `Bearer ${accessToken}`)
       .expect(204);
   });
+
+  it("액세스 토큰 없이 요청 시 401 Unauthorized 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .delete(`/diaries/${diaryUuid}`)
+      .expect(401);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toBe("Unauthorized");
+  });
 });

--- a/BE/test/diaries.delete.e2e-spec.ts
+++ b/BE/test/diaries.delete.e2e-spec.ts
@@ -65,4 +65,27 @@ describe("AppController (e2e)", () => {
 
     expect(body.message).toBe("Unauthorized");
   });
+
+  it("존재하지 않는 일기에 대한 요청 시 404 Not Found 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .delete(`/diaries/5d4a854d-cd2d-46a8-8adc-acec0270e4dc`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(404);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("존재하지 않는 일기입니다.");
+  });
+
+  // 유저 회원가입 및 로그인 후 글 생성하고 commonUser에서 해당 글에 대해 삭제 요청 보내기
+  // it("타인의 일기에 대한 요청 시 404 Not Found 응답", async () => {
+  //   const postResponse = await request(app.getHttpServer())
+  //     .delete(`/diaries/${diaryUuid}`)
+  //     .set("Authorization", `Bearer ${accessToken}`)
+  //     .expect(204);
+
+  //   const body = JSON.parse(postResponse.text);
+
+  //   expect(body.message).toContain("존재하지 않는 일기입니다.");
+  // });
 });

--- a/BE/test/diaries.delete.e2e-spec.ts
+++ b/BE/test/diaries.delete.e2e-spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "../src/app.module";
+import { ValidationPipe } from "@nestjs/common";
+
+describe("AppController (e2e)", () => {
+  let app: INestApplication;
+  let accessToken: string;
+  let diaryUuid: string;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
+    await app.init();
+
+    const signInPost = await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "commonUser",
+        password: process.env.COMMON_USER_PASS,
+      });
+
+    accessToken = signInPost.body.accessToken;
+
+    const createDiaryPost = await request(app.getHttpServer())
+      .post("/diaries")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        title: "title",
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        date: "2023-11-14",
+        tags: ["tagTest", "tagTest2"],
+        shapeUuid: "0c99bbc6-e404-464b-a310-5bf0fa0f0fa7",
+      });
+
+    diaryUuid = createDiaryPost.body.uuid;
+    console.log(diaryUuid);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("정상 요청 시 200 OK 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .delete(`/diaries/${diaryUuid}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(204);
+  });
+});


### PR DESCRIPTION
## 요약
- 일기 삭제 API 응답 수정
- 일기 삭제 e2e 테스트 작성

## 변경 사항

### 일기 삭제 API 응답 수정
- 일기 정상 삭제 시 204 No Content 응답
- 액세스 토큰 없이 요청 시 401 Unauthorized 응답
- 타인의 일기에 대해 요청 시 404 Not Found 응답
- 존재하지 않는 일기에 대해 요청 시 404 Not Found 응답

### 일기 삭제 e2e 테스트 작성
- 정상 요청 시 200 OK 응답하는 e2e 테스트 코드 작성
- 액세스 토큰 없이 요청 시 401 Unauthorized 응답하는 e2e 테스트 코드 작성
- 존재하지 않는 일기에 대한 요청 시 404 Not Found 응답하는 e2e 테스트 코드 작성

## 참고 사항

### 실행 결과
정상 요청 시 200 OK 응답
![일기 정상 삭제](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/410d81b7-d27a-4553-bb0e-61f360930bd3)

액세스 토큰 없이 요청 시 401 Unauthorized 응답
![일기 삭제 토큰없음](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/cb781610-0c00-468b-aae0-d7cac4b1ed66)

존재하지 않는 일기에 대한 요청 시 404 Not Found 응답
![일기 삭제 일기없음](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/dcd1eff5-1e6e-4e55-8c6e-6db41b503450)

타인의 일기에 대해 요청 시 404 Not Found 응답
![일기 삭제 타인](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/441d8808-afc5-4571-af64-906da812c870)

## 이슈 번호
#96 