### PR TITLE
[Feat] 일기 삭제 API 연동

### DIFF
--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -1,11 +1,30 @@
 import React from "react";
+import { useMutation } from "react-query";
 import styled from "styled-components";
-import { useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import diaryAtom from "../../atoms/diaryAtom";
+import userAtom from "../../atoms/userAtom";
 import ModalWrapper from "../../styles/Modal/ModalWrapper";
 
+async function deleteDiaryFn(data) {
+  return fetch(`http://223.130.129.145:3005/diaries/${data.diaryUuid}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${data.accessToken}`,
+    },
+  });
+}
+
 function DiaryDeleteModal() {
+  const diaryState = useRecoilValue(diaryAtom);
+  const userState = useRecoilValue(userAtom);
   const setDiaryState = useSetRecoilState(diaryAtom);
+  const {
+    mutate: deleteDiary,
+    // isLoading,
+    // error,
+  } = useMutation(deleteDiaryFn);
 
   return (
     <DeleteModalWrapper left='50%' width='15vw' height='10vh' opacity='0'>
@@ -23,6 +42,10 @@ function DiaryDeleteModal() {
         </DeleteModalButton>
         <DeleteModalButton
           onClick={() => {
+            deleteDiary({
+              diaryUuid: diaryState.diaryUuid,
+              accessToken: userState.accessToken,
+            });
             setDiaryState((prev) => ({
               ...prev,
               isRead: false,

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -15,7 +15,7 @@ function MainPage() {
       <MainPageWrapper
         onClick={(e) => {
           e.preventDefault();
-          setDiaryState((prev) => ({ ...prev, isRead: true }));
+          setDiaryState((prev) => ({ ...prev, isCreate: true }));
         }}
       >
         <MainTitle>대충 메인 페이지</MainTitle>


### PR DESCRIPTION
## 요약

- 일기 삭제 API 연동

https://github.com/boostcampwm2023/web08-ByeolSoop/assets/67178684/b98e0c4d-0811-4f38-acd7-3af18aa211b3


## 변경 사항

- 메인 페이지 클릭 시 일기 생성 모달 표시하도록 변경
- react-query 활용 일기 삭제 API 연동

## 참고 사항

- 추후 전체 일기 정보를 가져오는 함수를 메인 페이지에서 실행하도록 수정해야 함
- 일기가 없을 경우, 일기 나열 가장 오른쪽 모달을 띄우지 말아야 할 듯

## 이슈 번호

close #99 
