### PR TITLE
[Feat] 일기 로딩 애니메이션 구현

### DIFF
--- a/FE/src/atoms/diaryAtom.js
+++ b/FE/src/atoms/diaryAtom.js
@@ -7,6 +7,7 @@ const diaryAtom = atom({
     isRead: false,
     isDelete: false,
     isList: false,
+    isLoaded: false,
     diaryUuid: "1",
   },
 });

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -8,26 +8,6 @@ import ModalWrapper from "../../styles/Modal/ModalWrapper";
 import DiaryModalHeader from "../../styles/Modal/DiaryModalHeader";
 import deleteIcon from "../../assets/deleteIcon.svg";
 
-async function getShapeFn() {
-  return fetch("http://223.130.129.145:3005/shapes/default", {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  }).then((res) => res.json());
-}
-
-async function createDiaryFn(data) {
-  return fetch("http://223.130.129.145:3005/diaries", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${data.accessToken}`,
-    },
-    body: JSON.stringify(data.diaryData),
-  }).then((res) => res.json());
-}
-
 // TODO: 일기 데이터 수정 API 연결
 function DiaryCreateModal() {
   const [isInput, setIsInput] = React.useState(false);
@@ -66,6 +46,42 @@ function DiaryCreateModal() {
   const deleteLastTag = () => {
     setDiaryData({ ...diaryData, tags: diaryData.tags.slice(0, -1) });
   };
+
+  async function getShapeFn() {
+    return fetch("http://223.130.129.145:3005/shapes/default", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then((res) => res.json());
+  }
+
+  async function createDiaryFn(data) {
+    return fetch("http://223.130.129.145:3005/diaries", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${data.accessToken}`,
+      },
+      body: JSON.stringify(data.diaryData),
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        setDiaryState((prev) => ({
+          ...prev,
+          isLoading: true,
+        }));
+        setTimeout(() => {
+          setDiaryState((prev) => ({
+            ...prev,
+            isCreate: false,
+            isRead: true,
+            isLoading: false,
+            diaryUuid: res.uuid,
+          }));
+        }, 3000);
+      });
+  }
 
   const {
     data: shapeData,

--- a/FE/src/components/DiaryModal/DiaryLoadingModal.js
+++ b/FE/src/components/DiaryModal/DiaryLoadingModal.js
@@ -1,0 +1,71 @@
+import React from "react";
+import styled from "styled-components";
+import ModalWrapper from "../../styles/Modal/ModalWrapper";
+import {
+  LoadingAnimationWrapper,
+  LoadingAnimationIcon,
+} from "../../styles/Modal/LoadingAnimation";
+
+function DiaryLoadingModal() {
+  return (
+    <>
+      <DiaryLoadingModalWrapper>
+        <LoadingAnimationWrapper>
+          <LoadingAnimationIcon />
+        </LoadingAnimationWrapper>
+        <DiaryLoadingTitle>일기 저장 중</DiaryLoadingTitle>
+        <DiaryLoadingContent>
+          감정 분석 결과와 함께
+          <br />
+          보여드릴게요.
+        </DiaryLoadingContent>
+      </DiaryLoadingModalWrapper>
+      <DiaryLoadingModalBackground />
+    </>
+  );
+}
+
+const DiaryLoadingModalWrapper = styled(ModalWrapper)`
+  width: 10rem;
+  height: 6rem;
+  padding: 2rem 4rem;
+  top: 45%;
+  left: 50%;
+  color: #ffffff;
+`;
+
+const DiaryLoadingTitle = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: 1.5rem;
+`;
+
+const DiaryLoadingContent = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: relative;
+  top: 2.5rem;
+
+  font-size: 1rem;
+  text-align: center;
+  line-height: 1.5rem;
+`;
+
+const DiaryLoadingModalBackground = styled.div`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1003;
+`;
+
+export default DiaryLoadingModal;

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -6,6 +6,7 @@ import DiaryCreateModal from "../components/DiaryModal/DiaryCreateModal";
 import DiaryReadModal from "../components/DiaryModal/DiaryReadModal";
 import background from "../assets/background.png";
 import DiaryListModal from "../components/DiaryModal/DiaryListModal";
+import DiaryLoadingModal from "../components/DiaryModal/DiaryLoadingModal";
 
 function MainPage() {
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
@@ -15,7 +16,7 @@ function MainPage() {
       <MainPageWrapper
         onClick={(e) => {
           e.preventDefault();
-          setDiaryState((prev) => ({ ...prev, isCreate: true }));
+          setDiaryState((prev) => ({ ...prev, isCreate: true, isRead: false }));
         }}
       >
         <MainTitle>대충 메인 페이지</MainTitle>
@@ -23,6 +24,7 @@ function MainPage() {
       {diaryState.isCreate ? <DiaryCreateModal /> : null}
       {diaryState.isRead ? <DiaryReadModal /> : null}
       {diaryState.isList ? <DiaryListModal /> : null}
+      {diaryState.isLoading ? <DiaryLoadingModal /> : null}
     </>
   );
 }

--- a/FE/src/styles/Modal/LoadingAnimation.js
+++ b/FE/src/styles/Modal/LoadingAnimation.js
@@ -1,0 +1,34 @@
+import styled, { keyframes } from "styled-components";
+
+const LoadingAnimation = keyframes`
+    0% {
+        transform: rotate(0deg);
+    }
+    50% {
+        transform: rotate(180deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+`;
+
+const LoadingAnimationWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  animation: ${LoadingAnimation} 1.5s linear infinite;
+`;
+
+const LoadingAnimationIcon = styled.div`
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 0.25rem solid #ffffff;
+  border-top: 0.25rem solid rgba(255, 255, 255, 0.3);
+`;
+
+export { LoadingAnimationWrapper, LoadingAnimationIcon };


### PR DESCRIPTION
## 요약

- 일기 로딩 애니메이션 구현

https://github.com/boostcampwm2023/web08-ByeolSoop/assets/67178684/603c2870-4839-4bed-a8e7-dff70daffe59


## 변경 사항

- diaryAtom에 로딩 모달 상태 관리 추가
- styles 폴더 내 로딩 애니메이션 CSS 작성
- 일기 로딩 모달 UI 작성
- 상태 수정을 통한 로딩 모달 표시

## 참고 사항

- 추후 일기 생성 성공 시 3초, 일기 생성 실패 시 무한 로딩 구현할 것

## 이슈 번호

close #109 
