### PR TITLE
[Feat] 일기 수정 API에 대한 서버 응답 수정 및 e2e 테스트 작성

### DIFF
--- a/BE/src/auth/guard/auth.diary-guard.ts
+++ b/BE/src/auth/guard/auth.diary-guard.ts
@@ -3,11 +3,11 @@ import {
   Injectable,
   NotFoundException,
 } from "@nestjs/common";
-import { AuthGuard } from "@nestjs/passport";
 import { DiariesRepository } from "src/diaries/diaries.repository";
+import { JwtAuthGuard } from "./auth.jwt-guard";
 
 @Injectable()
-export class PrivateDiaryGuard extends AuthGuard("jwt") {
+export class PrivateDiaryGuard extends JwtAuthGuard {
   constructor(private readonly diariesRepository: DiariesRepository) {
     super();
   }

--- a/BE/src/auth/guard/auth.jwt-guard.ts
+++ b/BE/src/auth/guard/auth.jwt-guard.ts
@@ -1,0 +1,19 @@
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { AuthGuard as NestAuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class JwtAuthGuard extends NestAuthGuard("jwt") {
+  handleRequest(err, user, info: Error) {
+    if (err || !user) {
+      if (info.message === "No auth token") {
+        throw new UnauthorizedException("비로그인 상태의 요청입니다.");
+      } else if (info.message === "jwt expired") {
+        throw new UnauthorizedException("토큰이 만료되었습니다.");
+      } else if (info.message === "invalid token") {
+        throw new UnauthorizedException("유효하지 않은 토큰입니다.");
+      }
+      throw err || new UnauthorizedException("Unauthorized");
+    }
+    return user;
+  }
+}

--- a/BE/src/auth/jwt.strategy.ts
+++ b/BE/src/auth/jwt.strategy.ts
@@ -13,7 +13,15 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload) {
+  async validate(payload: any): Promise<User> {
+    if (!payload) {
+      throw new UnauthorizedException();
+    }
+
+    if (!this.isValidPayload(payload)) {
+      throw new UnauthorizedException();
+    }
+
     const { userId } = payload;
     const user: User = await this.userRepository.getUserByUserId(userId);
 
@@ -21,5 +29,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException();
     }
     return user;
+  }
+
+  isValidPayload(payload: any) {
+    if (typeof payload !== "object") return false;
+    if (!payload.hasOwnProperty("userId")) return false;
+
+    return true;
   }
 }

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -17,15 +17,15 @@ import {
   UpdateDiaryDto,
 } from "./dto/diaries.dto";
 import { Diary } from "./diaries.entity";
-import { AuthGuard } from "@nestjs/passport";
 import { ReadDiaryDto, ReadDiaryResponseDto } from "./dto/diaries.read.dto";
 import { PrivateDiaryGuard } from "src/auth/guard/auth.diary-guard";
 import { GetUser } from "src/auth/get-user.decorator";
 import { User } from "src/users/users.entity";
 import { Tag } from "src/tags/tags.entity";
+import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
 
 @Controller("diaries")
-@UseGuards(AuthGuard())
+@UseGuards(JwtAuthGuard)
 export class DiariesController {
   constructor(private diariesService: DiariesService) {}
 
@@ -65,8 +65,13 @@ export class DiariesController {
 
   @Put()
   @UseGuards(PrivateDiaryGuard)
-  modifyDiary(@Body() updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
-    return this.diariesService.modifyDiary(updateDiaryDto);
+  @HttpCode(204)
+  async modifyDiary(
+    @Body() updateDiaryDto: UpdateDiaryDto,
+    @GetUser() user: User,
+  ): Promise<void> {
+    await this.diariesService.modifyDiary(updateDiaryDto, user);
+    return;
   }
 
   @Delete("/:uuid")

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -33,8 +33,12 @@ export class DiariesController {
   @HttpCode(201)
   async writeDiary(
     @Body() createDiaryDto: CreateDiaryDto,
+    @GetUser() user: User,
   ): Promise<DiaryUuidDto> {
-    const diary: Diary = await this.diariesService.writeDiary(createDiaryDto);
+    const diary: Diary = await this.diariesService.writeDiary(
+      createDiaryDto,
+      user,
+    );
     return { uuid: diary.uuid };
   }
 

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -16,17 +16,17 @@ export class DiariesRepository {
     createDiaryDto: CreateDiaryDto,
     encodedContent: string,
     tags: Tag[],
+    user: User,
   ): Promise<Diary> {
-    const { title, point, date } = createDiaryDto;
+    const { title, point, date, shapeUuid } = createDiaryDto;
     const content = encodedContent;
+    const shape = await Shape.findOne({ where: { uuid: shapeUuid } });
 
     // 미구현 기능을 대체하기 위한 임시 값
     const positiveRatio = 0.0;
     const negativeRatio = 100.0;
     const neutralRatio = 0.0;
     const sentiment = sentimentStatus.NEUTRAL;
-    const shape = await Shape.findOne({ where: { id: 1 } });
-    const user = await User.findOne({ where: { id: 1 } });
 
     const newDiary = Diary.create({
       title,

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -61,15 +61,35 @@ export class DiariesRepository {
 
   async updateDiary(
     updateDiaryDto: UpdateDiaryDto,
-    encodedContent: string,
+    encryptedContent: string,
+    tags: Tag[],
+    user: User,
   ): Promise<Diary> {
-    const { uuid, title, date, shapeUuid } = updateDiaryDto;
+    const { uuid, title, point, date, shapeUuid } = updateDiaryDto;
+    const content = encryptedContent;
+    const shape = await Shape.findOne({ where: { uuid: shapeUuid } });
+
+    // 미구현 기능을 대체하기 위한 임시 값
+    const positiveRatio = 0.0;
+    const negativeRatio = 100.0;
+    const neutralRatio = 0.0;
+    const sentiment = sentimentStatus.NEUTRAL;
+
     const diary = await this.getDiaryByUuid(uuid);
 
-    diary.title = title;
-    diary.date = date;
-    diary.content = encodedContent;
-    diary.shape = await Shape.findOne({ where: { uuid: shapeUuid } });
+    Object.assign(diary, {
+      title,
+      content,
+      point,
+      date,
+      positiveRatio,
+      negativeRatio,
+      neutralRatio,
+      sentiment,
+      shape,
+      user,
+      tags,
+    });
 
     await diary.save();
     return diary;

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -9,6 +9,7 @@ import {
 import { TagsRepository } from "src/tags/tags.repository";
 import { Tag } from "src/tags/tags.entity";
 import { ReadDiaryDto } from "./dto/diaries.read.dto";
+import { User } from "src/users/users.entity";
 
 @Injectable()
 export class DiariesService {
@@ -17,7 +18,7 @@ export class DiariesService {
     private tagsRepository: TagsRepository,
   ) {}
 
-  async writeDiary(createDiaryDto: CreateDiaryDto): Promise<Diary> {
+  async writeDiary(createDiaryDto: CreateDiaryDto, user: User): Promise<Diary> {
     const encodedContent = btoa(createDiaryDto.content);
     const tags = [];
 
@@ -36,6 +37,7 @@ export class DiariesService {
       createDiaryDto,
       encodedContent,
       tags,
+      user,
     );
 
     return diary;

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -91,7 +91,23 @@ export class DiariesService {
     return diaryList;
   }
 
-  async modifyDiary(updateDiaryDto: UpdateDiaryDto): Promise<Diary> {
+  async modifyDiary(
+    updateDiaryDto: UpdateDiaryDto,
+    user: User,
+  ): Promise<Diary> {
+    const tags = [];
+
+    await Promise.all(
+      updateDiaryDto.tags.map(async (tag) => {
+        if ((await Tag.findOne({ where: { name: tag } })) !== null) {
+          const tagEntity = await Tag.findOneBy({ name: tag });
+          tags.push(tagEntity);
+        } else {
+          tags.push(await this.tagsRepository.createTag(tag));
+        }
+      }),
+    );
+
     const cipher = createCipheriv(
       "aes-256-cbc",
       process.env.CONTENT_SECRET_KEY,
@@ -100,7 +116,12 @@ export class DiariesService {
     let encryptedContent = cipher.update(updateDiaryDto.content, "utf8", "hex");
     encryptedContent += cipher.final("hex");
 
-    return this.diariesRepository.updateDiary(updateDiaryDto, encryptedContent);
+    return this.diariesRepository.updateDiary(
+      updateDiaryDto,
+      encryptedContent,
+      tags,
+      user,
+    );
   }
 
   async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {

--- a/BE/src/diaries/dto/diaries.dto.ts
+++ b/BE/src/diaries/dto/diaries.dto.ts
@@ -35,34 +35,15 @@ export class CreateDiaryDto {
   shapeUuid: string;
 }
 
-export class UpdateDiaryDto {
-  @IsUUID()
+export class UpdateDiaryDto extends CreateDiaryDto {
+  @IsUUID("4", { message: "일기 uuid 값이 uuid 양식이어야 합니다." })
+  @IsNotEmpty({ message: "일기 uuid는 비어있지 않아야 합니다." })
   uuid: string;
-
-  @IsString()
-  title: string;
-
-  @IsString()
-  content: string;
-
-  @IsString()
-  @Matches(/^-?\d+(\.\d+)?,-?\d+(\.\d+)?,-?\d+(\.\d+)?$/, {
-    message: "적절하지 않은 포인트 양식입니다",
-  })
-  point: string;
-
-  @IsDate()
-  date: Date;
-
-  @IsArray()
-  tags: string[];
-
-  @IsUUID()
-  shapeUuid: string;
 }
 
 export class DeleteDiaryDto {
   @IsUUID("4", { message: "일기 uuid 값이 uuid 양식이어야 합니다." })
+  @IsNotEmpty({ message: "일기 uuid는 비어있지 않아야 합니다." })
   uuid: string;
 }
 

--- a/BE/src/diaries/dto/diaries.dto.ts
+++ b/BE/src/diaries/dto/diaries.dto.ts
@@ -1,6 +1,5 @@
 import {
   IsString,
-  IsDate,
   Matches,
   IsUUID,
   IsArray,

--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -8,10 +8,10 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { ShapesService } from "./shapes.service";
-import { AuthGuard } from "@nestjs/passport";
 import { Shape } from "./shapes.entity";
 import { GetUser } from "src/auth/get-user.decorator";
 import { User } from "src/users/users.entity";
+import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
 
 @Controller("shapes")
 export class ShapesController {
@@ -23,7 +23,7 @@ export class ShapesController {
   }
 
   @Get("/:uuid")
-  @UseGuards(AuthGuard())
+  @UseGuards(JwtAuthGuard)
   @Header("Content-Type", "image/png")
   async getShapeFilesByUuid(
     @Param("uuid") uuid: string,

--- a/BE/test/diaries.update.e2e-spec.ts
+++ b/BE/test/diaries.update.e2e-spec.ts
@@ -1,0 +1,329 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "../src/app.module";
+import { ValidationPipe } from "@nestjs/common";
+import { UsersRepository } from "src/users/users.repository";
+
+describe("[일기 수정] /diaries PUT (e2e)", () => {
+  let app: INestApplication;
+  let accessToken: string;
+  let diaryUuid: string;
+  let shapeUuid: string;
+  const userId = "commonUser";
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+      providers: [UsersRepository],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
+    await app.init();
+
+    const signInPost = await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId,
+        password: process.env.COMMON_USER_PASS,
+      });
+
+    accessToken = signInPost.body.accessToken;
+
+    const defaultShapes = await request(app.getHttpServer())
+      .get("/shapes/default")
+      .set("Authorization", `Bearer ${accessToken}`);
+    shapeUuid = defaultShapes.body[0]["uuid"];
+
+    const createResponse = await request(app.getHttpServer())
+      .post("/diaries")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        shapeUuid,
+        title: "title",
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        date: "2023-11-14",
+        tags: ["tagTest", "tagTest2"],
+      });
+
+    diaryUuid = createResponse.body.uuid;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("정상 요청 시 204 No Content 응답", async () => {
+    await request(app.getHttpServer())
+      .put("/diaries")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        title: "update title",
+        content: "this is content!",
+        point: "1.5,5.5,10.55",
+        date: "2023-12-14",
+        tags: ["tagTest", "tagTest2", "tagTest3"],
+      })
+      .expect(204);
+
+    const expectedResponse = {
+      uuid: diaryUuid,
+      userId,
+      shapeUuid,
+      title: "update title",
+      content: "this is content!",
+      date: "2023-12-14T00:00:00.000Z",
+      emotion: {
+        positive: 0,
+        neutral: 0,
+        negative: 100,
+        sentiment: "neutral",
+      },
+      coordinate: {
+        x: 1.5,
+        y: 5.5,
+        z: 10.55,
+      },
+      tags: expect.arrayContaining(["tagTest", "tagTest2", "tagTest3"]),
+    };
+
+    const postResponse = await request(app.getHttpServer())
+      .get(`/diaries/${diaryUuid}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(postResponse.body).toEqual(expectedResponse);
+  });
+
+  it("액세스 토큰 없이 요청 시 401 Unauthorized 응답", async () => {
+    await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        title: "update title",
+        content: "this is content!",
+        point: "1.5,5.5,10.55",
+        date: "2023-12-14",
+        tags: ["tagTest", "tagTest2", "tagTest3"],
+      })
+      .expect(401);
+
+    const postResponse = await request(app.getHttpServer())
+      .get(`/diaries/${diaryUuid}`)
+      .expect(401);
+
+    expect(postResponse.body).toEqual({
+      error: "Unauthorized",
+      message: "비로그인 상태의 요청입니다.",
+      statusCode: 401,
+    });
+  });
+
+  it("만료된 토큰 요청 시 401 Unauthorized 응답", async () => {
+    const expiredToken =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjb21tb25Vc2VyIiwiaWF0IjoxNzAwNjUxMDUxLCJleHAiOjE3MDA2NTQ2NTF9.kJlDPs8XICWA8fhuP8rT5lvYqKBsqp86hMmI-txmL54";
+    const postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        title: "update title",
+        content: "this is content!",
+        point: "1.5,5.5,10.55",
+        date: "2023-12-14",
+        tags: ["tagTest", "tagTest2", "tagTest3"],
+      })
+      .set("Authorization", `Bearer ${expiredToken}`)
+      .expect(401);
+
+    expect(postResponse.body).toEqual({
+      error: "Unauthorized",
+      message: "토큰이 만료되었습니다.",
+      statusCode: 401,
+    });
+  });
+
+  it("유효하지 않은 토큰 요청 시 401 Unauthorized 응답", async () => {
+    const expiredToken =
+      "1yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJjb21tb25Vc2VyIiwiaWF0IjoxNzAwNjUxMDUxLCJleHAiOjE3MDA2NTQ2NTF9.kJlDPs8XICWA8fhuP8rT5lvYqKBsqp86hMmI-txmL54";
+    const postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        title: "update title",
+        content: "this is content!",
+        point: "1.5,5.5,10.55",
+        date: "2023-12-14",
+        tags: ["tagTest", "tagTest2", "tagTest3"],
+      })
+      .set("Authorization", `Bearer ${expiredToken}`)
+      .expect(401);
+
+    expect(postResponse.body).toEqual({
+      error: "Unauthorized",
+      message: "유효하지 않은 토큰입니다.",
+      statusCode: 401,
+    });
+  });
+
+  it("존재하지 않는 일기 조회 요청 시 404 Not Found 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: shapeUuid,
+        shapeUuid,
+        title: "update title",
+        content: "this is content!",
+        point: "1.5,5.5,10.55",
+        date: "2023-12-14",
+        tags: ["tagTest", "tagTest2", "tagTest3"],
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(404);
+
+    expect(postResponse.body).toEqual({
+      error: "Not Found",
+      message: "존재하지 않는 일기입니다.",
+      statusCode: 404,
+    });
+  });
+
+  it("빈 값을 포함한 요청 시 400 Bad Request 응답", async () => {
+    let postResponse;
+
+    // uuid가 없는 경우
+    postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        shapeUuid,
+        title: "title",
+        content: "this is content.",
+        date: "2023-11-14",
+        point: "1.5,5.5,10.55",
+        tags: ["tagTest", "tagTest2"],
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(400);
+
+    expect(postResponse.body.message).toContain(
+      "일기 uuid는 비어있지 않아야 합니다.",
+    );
+
+    // 제목이 없는 경우
+    postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        date: "2023-11-14",
+        tags: ["tagTest", "tagTest2"],
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(400);
+
+    expect(postResponse.body.message).toContain(
+      "제목은 비어있지 않아야 합니다.",
+    );
+
+    // 좌표가 없는 경우
+    postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        title: "title",
+        content: "this is content.",
+        date: "2023-11-14",
+        tags: ["tagTest", "tagTest2"],
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(400);
+
+    expect(postResponse.body.message).toContain(
+      "좌표는 비어있지 않아야 합니다.",
+    );
+
+    // 날짜가 없는 경우
+    postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        title: "title",
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        tags: ["tagTest", "tagTest2"],
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(400);
+
+    expect(postResponse.body.message).toContain(
+      "날짜는 비어있지 않아야 합니다.",
+    );
+
+    // 모양 uuid가 없는 경우
+    postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        uuid: diaryUuid,
+        title: "title",
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        date: "2023-11-14",
+        tags: ["tagTest", "tagTest2"],
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(400);
+
+    expect(postResponse.body.message).toContain(
+      "모양 uuid는 비어있지 않아야 합니다.",
+    );
+
+    // 복수의 데이터가 없는 경우
+    postResponse = await request(app.getHttpServer())
+      .put("/diaries")
+      .send({
+        title: "title",
+        content: "this is content.",
+        tags: ["tagTest", "tagTest2"],
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(400);
+
+    expect(postResponse.body.message).toContain(
+      "날짜는 비어있지 않아야 합니다.",
+    );
+    expect(postResponse.body.message).toContain(
+      "좌표는 비어있지 않아야 합니다.",
+    );
+    expect(postResponse.body.message).toContain(
+      "모양 uuid는 비어있지 않아야 합니다.",
+    );
+  });
+
+  // 유저 회원가입 및 로그인 후 글 생성하고 commonUser에서 해당 글에 대해 조회 요청 보내기
+  // it("타인의 일기에 대한 요청 시 404 Not Found 응답", async () => {
+  //   const postResponse = await request(app.getHttpServer())
+  //     .get(`/diaries/${unauthorizedDiaryUuid}`)
+  //     .set("Authorization", `Bearer ${accessToken}`)
+  //     .expect(404);
+
+  //   co
+
+  //   expect(postResponse.body).toEqual({
+  //     error: "Not Found",
+  //     message: "존재하지 않는 일기입니다.",
+  //     statusCode: 404,
+  //   });
+  // });
+});

--- a/BE/test/e2e/auth.signin.e2e-spec.ts
+++ b/BE/test/e2e/auth.signin.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
+import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 
 describe("/auth/signin (e2e)", () => {

--- a/BE/test/e2e/diaries.create.e2e-spec.ts
+++ b/BE/test/e2e/diaries.create.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
+import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 
 describe("AppController (e2e)", () => {

--- a/BE/test/e2e/diaries.delete.e2e-spec.ts
+++ b/BE/test/e2e/diaries.delete.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
+import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 
 describe("AppController (e2e)", () => {

--- a/BE/test/e2e/diaries.read-list.e2e-spec.ts
+++ b/BE/test/e2e/diaries.read-list.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
+import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 
 describe("AppController (e2e)", () => {

--- a/BE/test/e2e/diaries.read.e2e-spec.ts
+++ b/BE/test/e2e/diaries.read.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
+import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { UsersRepository } from "src/users/users.repository";
 

--- a/BE/test/e2e/diaries.update.e2e-spec.ts
+++ b/BE/test/e2e/diaries.update.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
+import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { UsersRepository } from "src/users/users.repository";
 


### PR DESCRIPTION
## 요약

- 일기 수정 및 수정 API에 대한 서버 응답 수정 
  - `UpdateDiaryDto` 수정
  - `AuthGuard`를 상속받은 커스텀 `JwtAuthGuard` 구현 
- Fix: 일기 작성할 때 DTO에 저장된 shape, 로그인한 유저 정보를 올바르게 저장

## 변경 사항

### 일기 작성 시 유저 및 모양 정보를 올바르게 저장
- `@GetUser` 데코레이터를 사용하여 User 정보 가져오도록 추가
- `shapeUuid`에 해당하는 shape 객체 추가


### UpdateDiaryDto 수정
- `UpdateDiaryDto`가 `CreateDiaryDto`를 상속받도록 수정
  - `CreateDiaryDto`에서 `uuid`가 추가된 형태이기 때문에 상속으로 중복된 부분 처리
  - `uuid`에 대한 데이터 유효성 검사 추가
- `IsDate` 에서 `IsDateString`으로 데코레이터 변경


### AuthGuard를 상속받은 커스텀 JwtAuthGuard 구현 
- 예외 메시지를 커스텀하기 위해 추가
  - 토큰이 없는 경우: `message: "비로그인 상태의 요청입니다."`
  - 토큰이 만료된 경우: `message: "토큰이 만료되었습니다."`
  -  토큰이 유효하지 않은 경우: `message: "유효하지 않은 토큰입니다."`
    - header 및 payload에 대해서만 확인하는 것으로 추정
  - 이 외의 경우: `message: "Unauthorized"`
- 추가로 JwtStrategy 전략에 대한 검증 추가
  - `payload`가 없거나, 올바르지 않은 `payload`이거나 `user`가 없을 경우 `401` 반환
- 이전에 `AuthGuard()`를 사용하던 부분을 `JwtAuthGuard`로 수정


### 일기 수정 요청 시 정보를 읽어와 DB에 업데이트
1. DTO에서 받아온 일기 `uuid`를 통해 저장되어 있는 해당 일기 객체를 가져옴
2. `shapeUuid`를 통해 해당 모양 객체를 가져옴
3. 모양 객체를 포함한 변경된 데이터들을 [Object.assign](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) 함수를 통해 일기 객체에 붙여넣음
4. 이를 `save` 함수로 저장

- `Object.assign`을 사용한 이유
  -  `diary.title = title` 과 같은 반복된 작업을 이와 같이 함수를 통해 실행
- TypeORM의 `update` 함수를 사용하지 않은 이유
  - TypeORM에서는 many-to-many 관계를 가진 필드를 업데이트하는 것이 복잡한 작업이기 때문에, `update` 함수로 처리가 불가능
  - `update` 함수를 사용하면 아래와 같은 오류 발생
![image](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/b23d25e1-39b0-45d8-875d-137180de97c6)
- 성공 시 `204` 반환하도록 데코레이터 추가


### 일기 수정 e2e 테스트 케이스 작성
- 정상적인 요청: `204 No Content`
- 존재하지 않는 일기에 대한 요청: `404 Not Found`
- 액세스 토큰 없이(비로그인 상태로) 요청: `401 Unauthorized`
- 올바르지 않은 데이터로 요청: `400 Bad Request`

## 실행 결과

### 204 No Content
<img width="600" alt="스크린샷 2023-11-23 오전 1 26 34" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/26072dd1-cea6-4f7f-83d7-e252076a46fb">

### 401 Unauthorized
<img width="600" alt="스크린샷 2023-11-23 오전 1 20 32" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/5fffcbb1-15fa-4c17-983c-2a0e25c2ebc9">

<img width="600" alt="스크린샷 2023-11-23 오전 1 22 43" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/f00658c2-f5b9-42ac-9846-f62ed3622917">

<img width="600" alt="스크린샷 2023-11-23 오전 1 23 19" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/126cf345-5370-49df-a9ff-ab7fbad51635">

### 404 Not Found
<img width="600" alt="스크린샷 2023-11-23 오전 1 26 10" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/54629813-950e-4f31-9819-0499e45ed5c5">

### 400 Bad Request
<img width="600" alt="스크린샷 2023-11-23 오전 1 29 41" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/7d893760-7c91-4081-ae78-b7a5f0a62170">


## 참고 사항

- test/e2e 폴더 추가 및 구조 변경
- `JwtStrategy` 에서 `throw` 하는 에러는 어디서 잡아서 처리하는지 모르겠다..
- 에러 메시지 관리를 상수화로 하거나, 커스텀 에러를 만들어 반환하는 방식도 좋을 것 같다.
- 현재 tags를 가져오는 부분이 중복되고 있어 함수로 리팩토링하면 좋을 것 같다.
- 감정분석에 대해서는 항상 똑같은 임시값이 포함되고 있다.
  - 추후 구현 후 반영 필요

### 추가 수정 사항(Fix!)
- 똑같은 `uuid`의 게시물을 생성하더라도 오류가 나지 않는다.
  - unique 처리가 되고 있지 않은 것 같아 이에 대해 엔티티 부분 수정 필요
- 생성 및 업데이트 시 `shapeUuid`가 없을 경우 500 에러가 발생한다.
  - 현재 `this.getDiaryByUuid()`와 같이 가져오는 함수를 호출하는 경우에 대해서는 실패 시 `404 Not Found` 응답
  - `shape`의 경우 `const shape = await Shape.findOne({ where: { uuid: shapeUuid } });` 와 같이 직접적으로 `diaries.repository.ts` 부분에서 처리되고 있기 때문에 `shapes.repository.ts` 에서 구현된 함수를 통해 `404 Not Found` 에러가 되도록 수정 필요

## 이슈 번호

- #103
- close #104

