### PR TITLE
[Fix] shape 객체가 존재하지 않을 경우 404 Not Found 에러가 되도록 수정

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -17,7 +17,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "cross-env NODE_ENV=test jest --config ./test/jest-e2e.json"
+    "test:e2e": "cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/BE/src/diaries/diaries.module.ts
+++ b/BE/src/diaries/diaries.module.ts
@@ -6,10 +6,23 @@ import { DiariesRepository } from "./diaries.repository";
 import { Diary } from "./diaries.entity";
 import { AuthModule } from "src/auth/auth.module";
 import { TagsModule } from "src/tags/tags.module";
+import { ShapesModule } from "src/shapes/shapes.module";
+import { ShapesRepository } from "src/shapes/shapes.repository";
+import { TagsRepository } from "src/tags/tags.repository";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Diary]), AuthModule, TagsModule],
+  imports: [
+    TypeOrmModule.forFeature([Diary]),
+    AuthModule,
+    TagsModule,
+    ShapesModule,
+  ],
   controllers: [DiariesController],
-  providers: [DiariesService, DiariesRepository],
+  providers: [
+    DiariesService,
+    DiariesRepository,
+    TagsRepository,
+    ShapesRepository,
+  ],
 })
 export class DiariesModule {}

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -17,10 +17,10 @@ export class DiariesRepository {
     encodedContent: string,
     tags: Tag[],
     user: User,
+    shape: Shape,
   ): Promise<Diary> {
-    const { title, point, date, shapeUuid } = createDiaryDto;
+    const { title, point, date } = createDiaryDto;
     const content = encodedContent;
-    const shape = await Shape.findOne({ where: { uuid: shapeUuid } });
 
     // 미구현 기능을 대체하기 위한 임시 값
     const positiveRatio = 0.0;
@@ -64,10 +64,10 @@ export class DiariesRepository {
     encryptedContent: string,
     tags: Tag[],
     user: User,
+    shape: Shape,
   ): Promise<Diary> {
-    const { uuid, title, point, date, shapeUuid } = updateDiaryDto;
+    const { uuid, title, point, date } = updateDiaryDto;
     const content = encryptedContent;
-    const shape = await Shape.findOne({ where: { uuid: shapeUuid } });
 
     // 미구현 기능을 대체하기 위한 임시 값
     const positiveRatio = 0.0;

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -11,15 +11,19 @@ import { Tag } from "src/tags/tags.entity";
 import { ReadDiaryDto } from "./dto/diaries.read.dto";
 import { User } from "src/users/users.entity";
 import { createCipheriv, createDecipheriv } from "crypto";
+import { ShapesRepository } from "src/shapes/shapes.repository";
 
 @Injectable()
 export class DiariesService {
   constructor(
     private diariesRepository: DiariesRepository,
     private tagsRepository: TagsRepository,
+    private shapesRepository: ShapesRepository,
   ) {}
 
   async writeDiary(createDiaryDto: CreateDiaryDto, user: User): Promise<Diary> {
+    const { shapeUuid } = createDiaryDto;
+    const shape = await this.shapesRepository.getShapeByUuid(shapeUuid);
     const tags = [];
 
     const cipher = createCipheriv(
@@ -46,6 +50,7 @@ export class DiariesService {
       encryptedContent,
       tags,
       user,
+      shape,
     );
 
     return diary;
@@ -95,6 +100,8 @@ export class DiariesService {
     updateDiaryDto: UpdateDiaryDto,
     user: User,
   ): Promise<Diary> {
+    const { shapeUuid } = updateDiaryDto;
+    const shape = await this.shapesRepository.getShapeByUuid(shapeUuid);
     const tags = [];
 
     await Promise.all(
@@ -121,6 +128,7 @@ export class DiariesService {
       encryptedContent,
       tags,
       user,
+      shape,
     );
   }
 

--- a/BE/src/shapes/shapes.module.ts
+++ b/BE/src/shapes/shapes.module.ts
@@ -11,5 +11,6 @@ import { AuthModule } from "src/auth/auth.module";
   imports: [TypeOrmModule.forFeature([Shape]), UsersModule, AuthModule],
   controllers: [ShapesController],
   providers: [ShapesService, ShapesRepository],
+  exports: [ShapesRepository],
 })
 export class ShapesModule {}

--- a/BE/src/tags/tags.repository.ts
+++ b/BE/src/tags/tags.repository.ts
@@ -1,11 +1,20 @@
 import { Diary } from "src/diaries/diaries.entity";
 import { Tag } from "./tags.entity";
+import { NotFoundException } from "@nestjs/common";
 
 export class TagsRepository {
   async createTag(name: string): Promise<Tag> {
-    const tag = await Tag.create({ name: name });
+    const tag = await Tag.create({ name });
     await tag.save();
 
     return tag;
+  }
+
+  async getTagByName(name: string): Promise<Tag> {
+    const found = await Tag.findOne({ where: { name } });
+    if (!found) {
+      throw new NotFoundException(`Can't find Tag with name: [${name}]`);
+    }
+    return found;
   }
 }

--- a/BE/test/e2e/auth.signin.e2e-spec.ts
+++ b/BE/test/e2e/auth.signin.e2e-spec.ts
@@ -7,7 +7,7 @@ import { ValidationPipe } from "@nestjs/common";
 describe("/auth/signin (e2e)", () => {
   let app: INestApplication;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -18,7 +18,7 @@ describe("/auth/signin (e2e)", () => {
 
     await app.init();
   });
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
   });
 

--- a/BE/test/e2e/diaries.create.e2e-spec.ts
+++ b/BE/test/e2e/diaries.create.e2e-spec.ts
@@ -8,7 +8,7 @@ describe("AppController (e2e)", () => {
   let app: INestApplication;
   let accessToken: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -29,7 +29,7 @@ describe("AppController (e2e)", () => {
     accessToken = signInPost.body.accessToken;
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
   });
 
@@ -67,7 +67,7 @@ describe("AppController (e2e)", () => {
 
     const body = JSON.parse(postResponse.text);
 
-    expect(body.message).toBe("Unauthorized");
+    expect(body.message).toBe("비로그인 상태의 요청입니다.");
   });
 
   it("빈 값을 포함한 요청 시 400 Bad Request 응답", async () => {

--- a/BE/test/e2e/diaries.delete.e2e-spec.ts
+++ b/BE/test/e2e/diaries.delete.e2e-spec.ts
@@ -9,7 +9,7 @@ describe("AppController (e2e)", () => {
   let accessToken: string;
   let diaryUuid: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -44,7 +44,7 @@ describe("AppController (e2e)", () => {
     diaryUuid = createDiaryPost.body.uuid;
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
   });
 
@@ -62,7 +62,7 @@ describe("AppController (e2e)", () => {
 
     const body = JSON.parse(postResponse.text);
 
-    expect(body.message).toBe("Unauthorized");
+    expect(body.message).toBe("비로그인 상태의 요청입니다.");
   });
 
   it("존재하지 않는 일기에 대한 요청 시 404 Not Found 응답", async () => {

--- a/BE/test/e2e/diaries.read-list.e2e-spec.ts
+++ b/BE/test/e2e/diaries.read-list.e2e-spec.ts
@@ -8,7 +8,7 @@ describe("AppController (e2e)", () => {
   let app: INestApplication;
   let accessToken: string;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -29,7 +29,7 @@ describe("AppController (e2e)", () => {
     accessToken = signInPost.body.accessToken;
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
   });
 

--- a/BE/test/e2e/diaries.read.e2e-spec.ts
+++ b/BE/test/e2e/diaries.read.e2e-spec.ts
@@ -94,7 +94,7 @@ describe("[일기 조회] /diaries/:uuid (e2e)", () => {
 
     const body = postResponse.body;
 
-    expect(body.message).toBe("Unauthorized");
+    expect(body.message).toBe("비로그인 상태의 요청입니다.");
   });
 
   it("만료된 토큰 요청 시 401 Unauthorized 응답", async () => {


### PR DESCRIPTION
## 요약

- shape 객체가 존재하지 않을 경우 404 Not Found 에러가 되도록 수정
- e2e 테스트 실행 시 옵션 추가
- diaries.service.ts 중복된 부분 모듈화 



## 변경 사항

### shape 객체가 존재하지 않을 경우 404 Not Found 에러가 되도록 수정
- 아래 코드처럼 구현된 함수를 통해 shape 객체를 받아오도록 수정
  - `getShapeByUuid` 함수 내부에서 찾지 못했을 경우 Not Found 에러를 던지도록 처리

```typescript
const shape = await this.shapesRepository.getShapeByUuid(shapeUuid);
``` 

### e2e 테스트 실행 시 옵션 추가
- e2e 테스트 실행 시 DB 연결이 되지 않은 문제 발생
- `--runInBand --detectOpenHandles` 옵션 추가
  - `--runInBand`:  모든 테스트를 순차적으로 실행하라는 의미, 테스트 사이에 서로간의 상호작용을 방지하고자 할 때 유용
  - `--detectOpenHandles`: 테스트가 끝난 후에도 여전히 열려 있는 리소스를 감지하는 데 사용
- `beforeEach`에서 `beforeAll`로 수정

### `diaries.service.ts` 중복된 부분 모듈화 
- 일기 내용 암호화, 태그 엔티티 배열 가져오는 부분 모듈화

## 참고 사항

- 갑자기 테스트에서 이 경우에 대해 실패를 하고 있어요..!

<img width="871" alt="스크린샷 2023-11-23 오후 3 30 32" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/e5a2b006-fbeb-444a-8e00-8da16cbd49cd">

## 이슈 번호

- close #116

