### PR TITLE
[Refactor] 일기 e2e 테스트 코드들을 통합 테스트 코드로 변환 후 일기 e2e 테스트 코드 작성

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "cross-env NODE_ENV=test jest --config ./test/jest-e2e.json"
+    "test:e2e": "cross-env NODE_ENV=test jest --config ./test/jest-e2e.json",
+    "test:int": "cross-env NODE_ENV=test jest --config ./test/jest-int.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/BE/src/auth/guard/auth.jwt-guard.ts
+++ b/BE/src/auth/guard/auth.jwt-guard.ts
@@ -9,10 +9,8 @@ export class JwtAuthGuard extends NestAuthGuard("jwt") {
         throw new UnauthorizedException("비로그인 상태의 요청입니다.");
       } else if (info.message === "jwt expired") {
         throw new UnauthorizedException("토큰이 만료되었습니다.");
-      } else if (info.message === "invalid token") {
-        throw new UnauthorizedException("유효하지 않은 토큰입니다.");
       }
-      throw err || new UnauthorizedException("Unauthorized");
+      throw err || new UnauthorizedException("유효하지 않은 토큰입니다.");
     }
     return user;
   }

--- a/BE/test/e2e/diaries.e2e-spec.ts
+++ b/BE/test/e2e/diaries.e2e-spec.ts
@@ -1,0 +1,138 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "../../src/app.module";
+import { ValidationPipe } from "@nestjs/common";
+
+describe("일기 CRUD e2e 테스트", () => {
+  let app: INestApplication;
+  let accessToken: string;
+  let shapeUuid: string;
+  const userId = "commonUser";
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
+    await app.init();
+
+    const signInPost = await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "commonUser",
+        password: process.env.COMMON_USER_PASS,
+      });
+
+    accessToken = signInPost.body.accessToken;
+
+    const defaultShapes = await request(app.getHttpServer())
+      .get("/shapes/default")
+      .set("Authorization", `Bearer ${accessToken}`);
+    shapeUuid = defaultShapes.body[0]["uuid"];
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("/diaries API 테스트", async () => {
+    // 일기 생성
+    const postResponse = await request(app.getHttpServer())
+      .post("/diaries")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        shapeUuid,
+        title: "title",
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        date: "2023-11-14",
+        tags: ["tagTest", "tagTest2"],
+      })
+      .expect(201);
+
+    const diaryUuid = JSON.parse(postResponse.text).uuid;
+
+    // 생성한 일기 조회
+    const getResponse = await request(app.getHttpServer())
+      .get(`/diaries/${diaryUuid}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    const expectedResponse = {
+      uuid: diaryUuid,
+      userId,
+      shapeUuid,
+      title: "title",
+      content: "this is content.",
+      date: "2023-11-14T00:00:00.000Z",
+      emotion: {
+        positive: 0,
+        neutral: 0,
+        negative: 100,
+        sentiment: "neutral",
+      },
+      coordinate: {
+        x: 1.5,
+        y: 5.5,
+        z: 10.55,
+      },
+      tags: expect.arrayContaining(["tagTest", "tagTest2"]),
+    };
+
+    expect(getResponse.body).toEqual(expectedResponse);
+
+    // 생성한 일기 수정
+    await request(app.getHttpServer())
+      .put("/diaries")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        uuid: diaryUuid,
+        shapeUuid,
+        title: "update title",
+        content: "this is content!",
+        point: "1.5,5.5,10.55",
+        date: "2023-12-14",
+        tags: ["tagTest", "tagTest2", "tagTest3"],
+      })
+      .expect(204);
+
+    // 수정된 일기 조회
+    const getUpdatedResponse = await request(app.getHttpServer())
+      .get(`/diaries/${diaryUuid}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    const expectedUpdatedResponse = {
+      uuid: diaryUuid,
+      userId,
+      shapeUuid,
+      title: "update title",
+      content: "this is content!",
+      date: "2023-12-14T00:00:00.000Z",
+      emotion: {
+        positive: 0,
+        neutral: 0,
+        negative: 100,
+        sentiment: "neutral",
+      },
+      coordinate: {
+        x: 1.5,
+        y: 5.5,
+        z: 10.55,
+      },
+      tags: expect.arrayContaining(["tagTest", "tagTest2", "tagTest3"]),
+    };
+
+    expect(getUpdatedResponse.body).toEqual(expectedUpdatedResponse);
+
+    const deleteResponse = await request(app.getHttpServer())
+      .delete(`/diaries/${diaryUuid}`)
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(204);
+  });
+});

--- a/BE/test/int/auth.signin.int-spec.ts
+++ b/BE/test/int/auth.signin.int-spec.ts
@@ -3,13 +3,17 @@ import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
+import { AuthModule } from "src/auth/auth.module";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { typeORMConfig } from "src/configs/typeorm.config";
 
 describe("/auth/signin (e2e)", () => {
   let app: INestApplication;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig), AuthModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/BE/test/int/diaries.create.int-spec.ts
+++ b/BE/test/int/diaries.create.int-spec.ts
@@ -7,7 +7,7 @@ import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
-describe("AppController (e2e)", () => {
+describe("[일기 작성] /diaries POST 통합 테스트", () => {
   let app: INestApplication;
   let accessToken: string;
 
@@ -68,33 +68,29 @@ describe("AppController (e2e)", () => {
       })
       .expect(401);
 
+    expect(postResponse.body.message).toBe("비로그인 상태의 요청입니다.");
+  });
+
+  it("빈 제목을 포함한 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/diaries")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        content: "this is content.",
+        point: "1.5,5.5,10.55",
+        date: "2023-11-14",
+        tags: ["tagTest", "tagTest2"],
+        shapeUuid: "0c99bbc6-e404-464b-a310-5bf0fa0f0fa7",
+      })
+      .expect(400);
+
     const body = JSON.parse(postResponse.text);
 
-    expect(body.message).toBe("비로그인 상태의 요청입니다.");
-  });
-
-  it("빈 값을 포함한 요청 시 400 Bad Request 응답", async () => {
-    let postResponse;
-    let body;
-    // 제목이 없는 경우
-    postResponse = await request(app.getHttpServer())
-      .post("/diaries")
-      .set("Authorization", `Bearer ${accessToken}`)
-      .send({
-        content: "this is content.",
-        point: "1.5,5.5,10.55",
-        date: "2023-11-14",
-        tags: ["tagTest", "tagTest2"],
-        shapeUuid: "0c99bbc6-e404-464b-a310-5bf0fa0f0fa7",
-      })
-      .expect(400);
-
-    body = JSON.parse(postResponse.text);
-
     expect(body.message).toContain("제목은 비어있지 않아야 합니다.");
+  });
 
-    // 좌표가 없는 경우
-    postResponse = await request(app.getHttpServer())
+  it("빈 좌표를 포함한 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -106,12 +102,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("좌표는 비어있지 않아야 합니다.");
+  });
 
-    // 날짜가 없는 경우
-    postResponse = await request(app.getHttpServer())
+  it("빈 날짜를 포함한 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -123,12 +120,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("날짜는 비어있지 않아야 합니다.");
+  });
 
-    // 모양 uuid가 없는 경우
-    postResponse = await request(app.getHttpServer())
+  it("빈 모양 uuid를 포함한 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -140,12 +138,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("모양 uuid는 비어있지 않아야 합니다.");
+  });
 
-    // 복수의 데이터가 없는 경우
-    postResponse = await request(app.getHttpServer())
+  it("복수의 데이터가 빈 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -155,18 +154,15 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("날짜는 비어있지 않아야 합니다.");
     expect(body.message).toContain("좌표는 비어있지 않아야 합니다.");
     expect(body.message).toContain("모양 uuid는 비어있지 않아야 합니다.");
   });
 
-  it("부적절한 값으로 요청 시 400 Bad Request 응답", async () => {
-    let postResponse;
-    let body;
-    // 문자열이 아닌 제목으로 요청
-    postResponse = await request(app.getHttpServer())
+  it("문자열이 아닌 제목으로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -179,12 +175,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("제목은 문자열이어야 합니다.");
+  });
 
-    // 문자열이 아닌 내용으로 요청
-    postResponse = await request(app.getHttpServer())
+  it("문자열이 아닌 내용으로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -197,12 +194,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("내용은 문자열이어야 합니다.");
+  });
 
-    // 문자열이 아닌 좌표로 요청
-    postResponse = await request(app.getHttpServer())
+  it("문자열이 아닌 좌표로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -215,12 +213,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("좌표는 문자열이어야 합니다.");
+  });
 
-    // 적절하지 않은 좌표 양식의 문자열로 요청
-    postResponse = await request(app.getHttpServer())
+  it("적절하지 않은 좌표 양식으로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -233,12 +232,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("적절하지 않은 좌표 양식입니다.");
+  });
 
-    // 적절하지 않은 날짜 양식의 문자열로 요청
-    postResponse = await request(app.getHttpServer())
+  it("적절하지 않은 날짜 양식으로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -251,12 +251,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("date must be a valid ISO 8601 date string");
+  });
 
-    // 배열 형태가 아닌 태그로 요청
-    postResponse = await request(app.getHttpServer())
+  it("배열 형태가 아닌 태그로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -269,12 +270,13 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("태그는 배열의 형태여야 합니다.");
+  });
 
-    // uuid 양식이 아닌 모양 uuid로 요청
-    postResponse = await request(app.getHttpServer())
+  it("uuid 형태가 아닌 모양 uuid로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
       .post("/diaries")
       .set("Authorization", `Bearer ${accessToken}`)
       .send({
@@ -287,7 +289,7 @@ describe("AppController (e2e)", () => {
       })
       .expect(400);
 
-    body = JSON.parse(postResponse.text);
+    const body = JSON.parse(postResponse.text);
 
     expect(body.message).toContain("모양 uuid 값이 uuid 양식이어야 합니다.");
   });

--- a/BE/test/int/diaries.create.int-spec.ts
+++ b/BE/test/int/diaries.create.int-spec.ts
@@ -3,6 +3,9 @@ import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
+import { DiariesModule } from "src/diaries/diaries.module";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { TypeOrmModule } from "@nestjs/typeorm";
 
 describe("AppController (e2e)", () => {
   let app: INestApplication;
@@ -10,7 +13,7 @@ describe("AppController (e2e)", () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig), DiariesModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
@@ -67,7 +70,7 @@ describe("AppController (e2e)", () => {
 
     const body = JSON.parse(postResponse.text);
 
-    expect(body.message).toBe("Unauthorized");
+    expect(body.message).toBe("비로그인 상태의 요청입니다.");
   });
 
   it("빈 값을 포함한 요청 시 400 Bad Request 응답", async () => {

--- a/BE/test/int/diaries.delete.int-spec.ts
+++ b/BE/test/int/diaries.delete.int-spec.ts
@@ -7,7 +7,7 @@ import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
-describe("AppController (e2e)", () => {
+describe("[일기 삭제] /diaries/:uuid DELETE 통합 테스트", () => {
   let app: INestApplication;
   let accessToken: string;
   let diaryUuid: string;

--- a/BE/test/int/diaries.delete.int-spec.ts
+++ b/BE/test/int/diaries.delete.int-spec.ts
@@ -3,6 +3,9 @@ import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
+import { DiariesModule } from "src/diaries/diaries.module";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { TypeOrmModule } from "@nestjs/typeorm";
 
 describe("AppController (e2e)", () => {
   let app: INestApplication;
@@ -11,7 +14,7 @@ describe("AppController (e2e)", () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig), DiariesModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
@@ -62,7 +65,7 @@ describe("AppController (e2e)", () => {
 
     const body = JSON.parse(postResponse.text);
 
-    expect(body.message).toBe("Unauthorized");
+    expect(body.message).toBe("비로그인 상태의 요청입니다.");
   });
 
   it("존재하지 않는 일기에 대한 요청 시 404 Not Found 응답", async () => {

--- a/BE/test/int/diaries.read-list.int-spec.ts
+++ b/BE/test/int/diaries.read-list.int-spec.ts
@@ -3,6 +3,9 @@ import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
+import { DiariesModule } from "src/diaries/diaries.module";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { TypeOrmModule } from "@nestjs/typeorm";
 
 describe("AppController (e2e)", () => {
   let app: INestApplication;
@@ -10,7 +13,7 @@ describe("AppController (e2e)", () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig), DiariesModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/BE/test/int/diaries.read-list.int-spec.ts
+++ b/BE/test/int/diaries.read-list.int-spec.ts
@@ -7,7 +7,7 @@ import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
-describe("AppController (e2e)", () => {
+describe("[전체 일기 조회] /diaries GET 통합 테스트", () => {
   let app: INestApplication;
   let accessToken: string;
 

--- a/BE/test/int/diaries.read.int-spec.ts
+++ b/BE/test/int/diaries.read.int-spec.ts
@@ -28,6 +28,8 @@ describe("[일기 조회] /diaries/:uuid GET 통합 테스트", () => {
 
     app = moduleFixture.createNestApplication();
     app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
     await app.init();
 
     const signInPost = await request(app.getHttpServer())

--- a/BE/test/int/diaries.read.int-spec.ts
+++ b/BE/test/int/diaries.read.int-spec.ts
@@ -4,8 +4,12 @@ import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { UsersRepository } from "src/users/users.repository";
+import { DiariesModule } from "src/diaries/diaries.module";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ShapesModule } from "src/shapes/shapes.module";
 
-describe("[일기 조회] /diaries/:uuid (e2e)", () => {
+describe("[일기 조회] /diaries/:uuid GET 통합 테스트", () => {
   let app: INestApplication;
   let accessToken: string;
   let diaryUuid: string;
@@ -14,14 +18,16 @@ describe("[일기 조회] /diaries/:uuid (e2e)", () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        DiariesModule,
+        ShapesModule,
+      ],
       providers: [UsersRepository],
     }).compile();
 
     app = moduleFixture.createNestApplication();
     app.enableCors();
-    app.useGlobalPipes(new ValidationPipe());
-
     await app.init();
 
     const signInPost = await request(app.getHttpServer())
@@ -94,7 +100,7 @@ describe("[일기 조회] /diaries/:uuid (e2e)", () => {
 
     const body = postResponse.body;
 
-    expect(body.message).toBe("Unauthorized");
+    expect(body.message).toBe("비로그인 상태의 요청입니다.");
   });
 
   it("만료된 토큰 요청 시 401 Unauthorized 응답", async () => {
@@ -106,8 +112,10 @@ describe("[일기 조회] /diaries/:uuid (e2e)", () => {
       .expect(401);
 
     const body = postResponse.body;
-
-    expect(body.message).toBe("Unauthorized");
+    expect(
+      postResponse.body.message === "토큰이 만료되었습니다." ||
+        postResponse.body.message === "유효하지 않은 토큰입니다.",
+    ).toBeTruthy();
   });
 
   it("존재하지 않는 일기 조회 요청 시 404 Not Found 응답", async () => {

--- a/BE/test/int/diaries.update.int-spec.ts
+++ b/BE/test/int/diaries.update.int-spec.ts
@@ -4,6 +4,10 @@ import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { UsersRepository } from "src/users/users.repository";
+import { DiariesModule } from "src/diaries/diaries.module";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ShapesModule } from "src/shapes/shapes.module";
 
 describe("[일기 수정] /diaries PUT (e2e)", () => {
   let app: INestApplication;
@@ -14,7 +18,11 @@ describe("[일기 수정] /diaries PUT (e2e)", () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        DiariesModule,
+        ShapesModule,
+      ],
       providers: [UsersRepository],
     }).compile();
 
@@ -143,11 +151,10 @@ describe("[일기 수정] /diaries PUT (e2e)", () => {
       .set("Authorization", `Bearer ${expiredToken}`)
       .expect(401);
 
-    expect(postResponse.body).toEqual({
-      error: "Unauthorized",
-      message: "토큰이 만료되었습니다.",
-      statusCode: 401,
-    });
+    expect(
+      postResponse.body.message === "토큰이 만료되었습니다." ||
+        postResponse.body.message === "유효하지 않은 토큰입니다",
+    ).toBeTruthy();
   });
 
   it("유효하지 않은 토큰 요청 시 401 Unauthorized 응답", async () => {
@@ -310,20 +317,19 @@ describe("[일기 수정] /diaries PUT (e2e)", () => {
       "모양 uuid는 비어있지 않아야 합니다.",
     );
   });
-
-  // 유저 회원가입 및 로그인 후 글 생성하고 commonUser에서 해당 글에 대해 조회 요청 보내기
-  // it("타인의 일기에 대한 요청 시 404 Not Found 응답", async () => {
-  //   const postResponse = await request(app.getHttpServer())
-  //     .get(`/diaries/${unauthorizedDiaryUuid}`)
-  //     .set("Authorization", `Bearer ${accessToken}`)
-  //     .expect(404);
-
-  //   co
-
-  //   expect(postResponse.body).toEqual({
-  //     error: "Not Found",
-  //     message: "존재하지 않는 일기입니다.",
-  //     statusCode: 404,
-  //   });
-  // });
 });
+// 유저 회원가입 및 로그인 후 글 생성하고 commonUser에서 해당 글에 대해 조회 요청 보내기
+// it("타인의 일기에 대한 요청 시 404 Not Found 응답", async () => {
+//   const postResponse = await request(app.getHttpServer())
+//     .get(`/diaries/${unauthorizedDiaryUuid}`)
+//     .set("Authorization", `Bearer ${accessToken}`)
+//     .expect(404);
+
+//   co
+
+//   expect(postResponse.body).toEqual({
+//     error: "Not Found",
+//     message: "존재하지 않는 일기입니다.",
+//     statusCode: 404,
+//   });
+// });

--- a/BE/test/int/diaries.update.int-spec.ts
+++ b/BE/test/int/diaries.update.int-spec.ts
@@ -9,7 +9,7 @@ import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ShapesModule } from "src/shapes/shapes.module";
 
-describe("[일기 수정] /diaries PUT (e2e)", () => {
+describe("[일기 수정] /diaries PUT 통합 테스트", () => {
   let app: INestApplication;
   let accessToken: string;
   let diaryUuid: string;

--- a/BE/test/jest-int.json
+++ b/BE/test/jest-int.json
@@ -1,0 +1,12 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".int-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
+  }
+}


### PR DESCRIPTION
## 요약

- 일기 e2e 테스트 코드들을 통합 테스트 코드로 변환
- 일기 e2e 테스트 코드 작성

## 변경 사항

### 일기 e2e 테스트 코드들을 통합 테스트 코드로 변환
- 현재 작성해두었던 e2e 테스트는 e2e 테스트가 아니고 통합 테스트에 가까운 코드임
- 따라서 현재 e2e 테스트를 통합 테스트로 변환시키도록 함

### 일기 e2e 테스트 코드 작성
- 사용자의 관점에서 테스트를 진행하도록 하는 e2e 테스트 코드 작성
- 사용자가 일기를 생성하고, 조회하고, 수정하고, 수정한 일기를 조회하고, 삭제하는 e2e 테스트 작성
- 사용자가 일기를 생성하고 삭제한 후 삭제한 일기를 조회하는 실패 e2e 테스트 작성

## 참고 사항

- 이번 주는 구현한 기능에 대해 통합 테스트, e2e 테스트만 작성하기로 합의함. 단위 테스트는 추후 학습 후 구현 예정

## 이슈 번호
close #118 
