### PR TITLE
[Hotfix] 태그 찾을 때 비동기 처리로 인해 태그 생성 실패

### DIFF
--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -121,7 +121,8 @@ export class DiariesService {
     return await Promise.all(
       tagNames.map(async (tagName) => {
         try {
-          return this.tagsRepository.getTagByName(tagName);
+          const tag = await this.tagsRepository.getTagByName(tagName);
+          return tag;
         } catch {
           return await this.tagsRepository.createTag(tagName);
         }

--- a/BE/src/tags/tags.repository.ts
+++ b/BE/src/tags/tags.repository.ts
@@ -1,4 +1,3 @@
-import { Diary } from "src/diaries/diaries.entity";
 import { Tag } from "./tags.entity";
 import { NotFoundException } from "@nestjs/common";
 


### PR DESCRIPTION
## 요약

- 태그 찾을 때 비동기 처리로 인해 태그 생성 실패

## 변경 사항

### 태그 찾을 때 비동기 처리로 인해 태그 생성 실패
- Promise 객체를 반환하면서 에러가 제대로 catch 되지 않아서 수정

## 참고 사항

## 이슈 번호

