### PR TITLE
[Fix] 긴 일기 제목 UI 수정

### DIFF
--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -215,6 +215,9 @@ const DiaryTitleListItem = styled.div`
 
   cursor: pointer;
 
+  white-space: nowrap;
+  overflow-x: hidden;
+
   &:hover {
     background-color: rgba(255, 255, 255, 0.3);
   }

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -157,6 +157,11 @@ const DiaryModalHeader = styled.div`
 const DiaryModalTitle = styled.div`
   flex-grow: 1;
   font-size: 1.5rem;
+  line-height: 1.8rem;
+  width: 70%;
+
+  overflow-x: auto;
+  white-space: nowrap;
 `;
 
 const DiaryButton = styled.button`
@@ -165,7 +170,7 @@ const DiaryButton = styled.button`
   align-items: center;
   justify-content: center;
   width: 3rem;
-  height: 1rem;
+  height: 2rem;
   border: hidden;
   background: none;
 
@@ -210,6 +215,7 @@ const DiaryModalTag = styled.div`
   box-sizing: border-box;
   color: #ffffff;
   outline: none;
+  white-space: nowrap;
 `;
 
 const DiaryModalTagList = styled.div`


### PR DESCRIPTION
## 요약

### 긴 일기 제목 UI 수정
- 긴 일기 제목은 가로로 스크롤해서 보이도록 수정
- 리스트에서 긴 일기 제목은 hidden 처리

## 변경 사항

- 기존에는 긴 일기가 자동으로 줄바꿈되는 이슈가 있었는데, 이를 white-space: nowrap 옵션을 주어 줄바꿈되지 않도록 수정하였음.
- 추가적으로 tag에서도 같은 현상이 있었기에 tag에도 적용

## 이슈 번호

close #132 
