### PR TITLE
[Feat] 회원가입 API에 대한 서버 응답 수정 및 통합 테스트 작성

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { AuthCredentialsDto } from "./dto/auth-credential.dto";
 import { AccessTokenDto } from "./dto/auth-access-token.dto";
@@ -10,6 +10,7 @@ export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post("/signup")
+  @HttpCode(204)
   async signUp(@Body() createUserDto: CreateUserDto): Promise<void> {
     await this.authService.signUp(createUserDto);
     return;

--- a/BE/src/auth/dto/users.dto.ts
+++ b/BE/src/auth/dto/users.dto.ts
@@ -1,31 +1,35 @@
-import { IsString, Length, MaxLength, Matches } from "class-validator";
+import {
+  IsString,
+  Length,
+  MaxLength,
+  Matches,
+  IsNotEmpty,
+} from "class-validator";
 
 export class CreateUserDto {
-  @IsString()
-  @Matches(/^[A-Za-z0-9-]{5,20}$/)
+  @IsNotEmpty({ message: "아이디는 비어있지 않아야 합니다." })
+  @IsString({ message: "아이디는 문자열이어야 합니다." })
+  @Matches(/^[A-Za-z0-9-]{5,20}$/, {
+    message: "생성 규칙에 맞지 않는 아이디입니다.",
+  })
   userId: string;
 
-  @IsString()
+  @IsNotEmpty({ message: "이메일은 비어있지 않아야 합니다." })
+  @IsString({ message: "이메일은 문자열이어야 합니다." })
   @Matches(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, {
     message: "적절하지 않은 이메일 양식입니다.",
   })
   email: string;
 
-  @IsString()
-  @Matches(/^[A-Za-z0-9!@#$%^&*()+=-~]{5,20}$/)
+  @IsNotEmpty({ message: "비밀번호는 비어있지 않아야 합니다." })
+  @IsString({ message: "비밀번호는 문자열이어야 합니다." })
+  @Matches(/^[A-Za-z0-9!@#$%^&*()+=-~]{5,20}$/, {
+    message: "생성 규칙에 맞지 않는 비밀번호 입니다.",
+  })
   password: string;
 
-  @IsString()
-  @MaxLength(21)
+  @IsNotEmpty({ message: "닉네임은 비어있지 않아야 합니다." })
+  @IsString({ message: "닉네임은 문자열이어야 합니다." })
+  @MaxLength(21, { message: "닉네임은 20자 이하여야 합니다." })
   nickname: string;
-}
-
-export class LoginUserDto {
-  @IsString()
-  @Length(5, 20)
-  userId: string;
-
-  @IsString()
-  @Length(5, 20)
-  password: string;
 }

--- a/BE/src/auth/users.entity.ts
+++ b/BE/src/auth/users.entity.ts
@@ -14,7 +14,8 @@ import { Diary } from "../diaries/diaries.entity";
 import { Shape } from "src/shapes/shapes.entity";
 
 @Entity()
-@Unique(["userId", "email"])
+@Unique(["userId"])
+@Unique(["email"])
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -206,4 +206,68 @@ describe("[회원가입] /auth/signup POST 통합 테스트", () => {
 
     expect(body.message).toContain("닉네임은 비어있지 않아야 합니다.");
   });
+
+  it("문자열이 아닌 아이디로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: 36,
+        password: "TestPassword",
+        email: "testemail@naver.com",
+        nickname: "TestUser",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("아이디는 문자열이어야 합니다.");
+  });
+
+  it("문자열이 아닌 비밀번호로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        password: 36,
+        email: "testemail@naver.com",
+        nickname: "TestUser",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("비밀번호는 문자열이어야 합니다.");
+  });
+
+  it("문자열이 아닌 이메일로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        password: "TestPassword",
+        email: 36,
+        nickname: "TestUser",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("이메일은 문자열이어야 합니다.");
+  });
+
+  it("문자열이 아닌 닉네임으로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        password: "TestPassword",
+        email: "testemail@naver.com",
+        nickname: 36,
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("닉네임은 문자열이어야 합니다.");
+  });
 });

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -40,16 +40,18 @@ describe("[회원가입] /auth/signup POST 통합 테스트", () => {
       .expect(204);
 
     const testUser = await User.findOne({ where: { userId: "TestUserId" } });
-    await User.remove(testUser);
+    if (testUser) {
+      await User.remove(testUser);
+    }
   });
 
   it("중복된 아이디에 대한 요청 시 409 Conflict 응답", async () => {
     await request(app.getHttpServer())
       .post("/auth/signup")
       .send({
-        userId: "TestUserId",
+        userId: "TestUserId2",
         password: "TestPassword",
-        email: "testemail@naver.com",
+        email: "testemail2@naver.com",
         nickname: "TestUser",
       })
       .expect(204);
@@ -57,14 +59,43 @@ describe("[회원가입] /auth/signup POST 통합 테스트", () => {
     const postResponse = await request(app.getHttpServer())
       .post("/auth/signup")
       .send({
-        userId: "TestUserId",
-        password: "TestPassword2",
-        email: "testemail2@naver.com",
-        nickname: "TestUser2",
+        userId: "TestUserId2",
+        password: "TestPassword3",
+        email: "testemail3@naver.com",
+        nickname: "TestUser3",
       })
       .expect(409);
 
-    const testUser = await User.findOne({ where: { userId: "TestUserId" } });
-    await User.remove(testUser);
+    const testUser = await User.findOne({ where: { userId: "TestUserId2" } });
+    if (testUser) {
+      await User.remove(testUser);
+    }
+  });
+
+  it("중복된 이메일에 대한 요청 시 409 Conflict 응답", async () => {
+    await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUserId4",
+        password: "TestPassword4",
+        email: "testemail4@naver.com",
+        nickname: "TestUser4",
+      })
+      .expect(204);
+
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUserId5",
+        password: "TestPassword5",
+        email: "testemail4@naver.com",
+        nickname: "TestUser5",
+      })
+      .expect(409);
+
+    const testUser = await User.findOne({ where: { userId: "TestUserId4" } });
+    if (testUser) {
+      await User.remove(testUser);
+    }
   });
 });

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -146,4 +146,64 @@ describe("[회원가입] /auth/signup POST 통합 테스트", () => {
 
     expect(body.message).toContain("적절하지 않은 이메일 양식입니다.");
   });
+
+  it("빈 아이디로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        password: "TestPassword",
+        email: "testemail@naver.com",
+        nickname: "TestUser",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("아이디는 비어있지 않아야 합니다.");
+  });
+
+  it("빈 비밀번호로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        email: "testemail@naver.com",
+        nickname: "TestUser",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("비밀번호는 비어있지 않아야 합니다.");
+  });
+
+  it("빈 이메일로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        password: "TestPassword",
+        nickname: "TestUser",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("이메일은 비어있지 않아야 합니다.");
+  });
+
+  it("빈 닉네임으로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        password: "TestPassword",
+        email: "testemail@naver.com",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("닉네임은 비어있지 않아야 합니다.");
+  });
 });

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -42,4 +42,29 @@ describe("[회원가입] /auth/signup POST 통합 테스트", () => {
     const testUser = await User.findOne({ where: { userId: "TestUserId" } });
     await User.remove(testUser);
   });
+
+  it("중복된 아이디에 대한 요청 시 409 Conflict 응답", async () => {
+    await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUserId",
+        password: "TestPassword",
+        email: "testemail@naver.com",
+        nickname: "TestUser",
+      })
+      .expect(204);
+
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUserId",
+        password: "TestPassword2",
+        email: "testemail2@naver.com",
+        nickname: "TestUser2",
+      })
+      .expect(409);
+
+    const testUser = await User.findOne({ where: { userId: "TestUserId" } });
+    await User.remove(testUser);
+  });
 });

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -98,4 +98,52 @@ describe("[회원가입] /auth/signup POST 통합 테스트", () => {
       await User.remove(testUser);
     }
   });
+
+  it("생성 규칙을 지키지 않는 아이디 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "Test",
+        password: "TestPassword",
+        email: "testemail4@naver.com",
+        nickname: "TestUser",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("생성 규칙에 맞지 않는 아이디입니다.");
+  });
+
+  it("생성 규칙을 지키지 않는 비밀번호 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser8",
+        password: "Test",
+        email: "testemail8@naver.com",
+        nickname: "TestUser8",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("생성 규칙에 맞지 않는 비밀번호 입니다.");
+  });
+
+  it("생성 규칙을 지키지 않는 이메일 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        password: "TestPassword9",
+        email: "testemailnaver.com",
+        nickname: "TestUser9",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("적절하지 않은 이메일 양식입니다.");
+  });
 });

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -270,4 +270,20 @@ describe("[회원가입] /auth/signup POST 통합 테스트", () => {
 
     expect(body.message).toContain("닉네임은 문자열이어야 합니다.");
   });
+
+  it("20자를 초과하는 닉네임으로 요청 시 400 Bad Request 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUser9",
+        password: "TestPassword",
+        email: "testemail@naver.com",
+        nickname: "testtesttesttesttesttesttetst",
+      })
+      .expect(400);
+
+    const body = JSON.parse(postResponse.text);
+
+    expect(body.message).toContain("닉네임은 20자 이하여야 합니다.");
+  });
 });

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "../../src/app.module";
+import { ValidationPipe } from "@nestjs/common";
+import { AuthModule } from "src/auth/auth.module";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { typeORMConfig } from "src/configs/typeorm.config";
+import { User } from "src/auth/users.entity";
+
+describe("[회원가입] /auth/signup POST 통합 테스트", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig), AuthModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("정상 요청 시 204 Created 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "TestUserId",
+        password: "TestPassword",
+        email: "testemail@naver.com",
+        nickname: "TestUser",
+      })
+      .expect(204);
+
+    const testUser = await User.findOne({ where: { userId: "TestUserId" } });
+    await User.remove(testUser);
+  });
+});


### PR DESCRIPTION
## 요약

- 회원가입 API 응답 수정
- 회원가입 통합 테스트 작성

## 변경 사항

### 회원가입 API 응답 수정
- 서버가 정상적인 요청을 수락한 경우 사용자를 생성하고 204 No Content 코드를 응답
- 서버가 중복된 아이디나 이메일에 대한 요청을 받은 경우 409 Conflict를 응답
- 서버가 생성 규칙을 지키지 않는 값으로 요청을 받은 경우 400 Bad Request를 응답

### 회원가입 통합 테스트 작성
- 정상 요청 시 204 No Content를 응답하는 통합 테스트 작성
- 중복된 아이디 혹은 이메일로 요청 시 409 Conflict를 응답하는 통합 테스트 작성
- 회원가입 생성 규칙을 지키지 않은 요청 시 400 Bad Request를 응답하는 통합 테스트 작성
- 빈 값을 포함한 요청 시 400 Bad Request를 응답하는 통합 테스트 작성
- 문자열이 아닌 값을 포함한 요청 시 400 Bad Request를 응답하는 통합 테스트 작성
- 21자를 초과하는 닉네임으로 요청 시 400 Bad Request를 응답하는 통합 테스트 작성

## 참고 사항

- 회원가입과 로그인 과정을 모두 포함하는 e2e 테스트 작성이 필요함

## 이슈 번호
close #129
