### PR TITLE
[Feat] 로그인 유지 및 로그아웃 로직 변경 구현

### DIFF
--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useLayoutEffect } from "react";
 import Reset from "styled-reset";
 import { createGlobalStyle } from "styled-components";
-import { useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import userAtom from "./atoms/userAtom";
 import Header from "./components/Header/Header";
 import HomePage from "./pages/HomePage";
@@ -35,7 +35,14 @@ const GlobalStyle = createGlobalStyle`
 `;
 
 function App() {
-  const userState = useRecoilValue(userAtom);
+  const [userState, setUserState] = useRecoilState(userAtom);
+
+  useLayoutEffect(() => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (accessToken) {
+      setUserState({ ...userState, isLogin: true, accessToken });
+    }
+  }, []);
 
   return (
     <div className='App'>

--- a/FE/src/components/LoginModal/LoginModal.js
+++ b/FE/src/components/LoginModal/LoginModal.js
@@ -40,6 +40,7 @@ function LoginModal() {
             isLogin: true,
             accessToken: data.accessToken,
           }));
+          localStorage.setItem("accessToken", data.accessToken);
         } else {
           errorRef.current.innerText = data.message;
         }

--- a/FE/src/components/SideBar/SideBar.js
+++ b/FE/src/components/SideBar/SideBar.js
@@ -61,6 +61,7 @@ function SideBar() {
               isLogin: false,
               accessToken: "",
             }));
+            localStorage.removeItem("accessToken");
           }}
         >
           로그아웃


### PR DESCRIPTION
## 요약

### 로그인 유지 구현
- localStorage에 accessToken을 저장하는 로직을 구현

### 로그아웃 로직 변경 구현
- localStorage에서 accessToken을 삭제하고 홈페이지로 이동시키는 로직 구현

## 변경 사항

- useLayoutEffect를 이용해 새로고침이 되었을 때 현재 localStorage에 accessToken이 존재하는지 확인하고 홈페이지 혹은 메인페이지를 띄울 지 결정하는 로직을 구현하였습니다.
- localStorage의 get, set, remove을 통해 각 상황마다 accessToken을 localStorage에서 변경하는 작업을 구현하였습니다.

## 참고 사항

- refreshToken이 구현되고 난 이후에는 로직이 다시 바뀌어야 합니다.

## 이슈 번호

close #134 
