### PR TITLE
[Fix] 읽기 모달 개행 문제 수정, 리스트 타이틀 넘침 시 말줄임표 추가

### DIFF
--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -92,7 +92,7 @@ const DeleteModalButton = styled.button`
   font-family: "Pretendard-Medium";
   font-size: 1.2rem;
   cursor: pointer;
-  color: ${(props) => props.color || "#000000"};)};
+  color: ${(props) => props.color || "#000000"};
 `;
 
 export default DiaryDeleteModal;

--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -207,16 +207,20 @@ const DiaryTitleListItem = styled.div`
   height: 4.5rem;
   border-top: 0.5px solid #ffffff;
 
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  display: block;
+  text-align: center;
+  line-height: 4.5rem;
+
+  padding: 0 1rem;
+  box-sizing: border-box;
 
   flex-shrink: 0;
 
   cursor: pointer;
 
   white-space: nowrap;
-  overflow-x: hidden;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &:hover {
     background-color: rgba(255, 255, 255, 0.3);
@@ -258,6 +262,8 @@ const DiaryContent = styled.div`
   line-height: 1.8rem;
 
   overflow-y: auto;
+
+  white-space: pre-wrap;
 `;
 
 export default DiaryListModal;

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -191,6 +191,8 @@ const DiaryModalContent = styled.div`
   height: 60%;
   line-height: 1.8rem;
   overflow-y: auto;
+
+  white-space: pre-wrap;
 `;
 
 const DiaryModalTagName = styled.div`


### PR DESCRIPTION
## 요약

### 읽기 모달 개행 버그 fix

### 리스트 보기 제목에 말줄임표 추가

<img width="1680" alt="스크린샷 2023-11-27 오후 4 26 27" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023654/2dd76f16-4fe3-41fb-94bb-b1b58fb1c115">


## 변경 사항

- 읽기 모달에 개행이 정상적으로 출력되지 않는 문제점을 수정
- 리스트 제목이 넘칠 시 말줄임표로 ...을 추가하여 UI 개선

## 이슈 번호

close #143 
