### PR TITLE
[chore] 로그인 유지 박스 기능 추가, 회원가입 클릭 시 뷰 전환

### DIFF
--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -38,7 +38,8 @@ function App() {
   const [userState, setUserState] = useRecoilState(userAtom);
 
   useLayoutEffect(() => {
-    const accessToken = localStorage.getItem("accessToken");
+    let accessToken = localStorage.getItem("accessToken");
+    accessToken = accessToken || sessionStorage.getItem("accessToken");
     if (accessToken) {
       setUserState({ ...userState, isLogin: true, accessToken });
     }

--- a/FE/src/components/LoginModal/LoginModal.js
+++ b/FE/src/components/LoginModal/LoginModal.js
@@ -14,6 +14,7 @@ import naver from "../../assets/naver.png";
 
 function LoginModal() {
   const [userId, setUserId] = useState("");
+  const [keepLogin, setKeepLogin] = useState(false);
   const [password, setPassword] = useState("");
   const setUserState = useSetRecoilState(userAtom);
   const setHeaderState = useSetRecoilState(headerAtom);
@@ -40,7 +41,9 @@ function LoginModal() {
             isLogin: true,
             accessToken: data.accessToken,
           }));
-          localStorage.setItem("accessToken", data.accessToken);
+          if (keepLogin) {
+            localStorage.setItem("accessToken", data.accessToken);
+          }
         } else {
           errorRef.current.innerText = data.message;
         }
@@ -87,7 +90,11 @@ function LoginModal() {
             onChange={(e) => setPassword(e.target.value)}
           />
           <CheckBar>
-            <input type='checkbox' />
+            <input
+              type='checkbox'
+              checked={keepLogin}
+              onChange={setKeepLogin}
+            />
             <div>로그인 유지</div>
           </CheckBar>
         </InputBar>
@@ -97,7 +104,15 @@ function LoginModal() {
             로그인
           </ModalButton>
         </ModalButtonContainer>
-        <HelpBar>
+        <HelpBar
+          onClick={() => {
+            setHeaderState((prev) => ({
+              ...prev,
+              isLogin: false,
+              isSignUp: true,
+            }));
+          }}
+        >
           <div>회원가입</div>
           <HelpBarBorder />
           <div>아이디/비밀번호 찾기</div>
@@ -165,6 +180,8 @@ const HelpBar = styled.div`
 
   font-size: 1rem;
   color: #ffffff;
+
+  cursor: pointer;
 `;
 
 const HelpBarBorder = styled.div`

--- a/FE/src/components/LoginModal/LoginModal.js
+++ b/FE/src/components/LoginModal/LoginModal.js
@@ -43,6 +43,8 @@ function LoginModal() {
           }));
           if (keepLogin) {
             localStorage.setItem("accessToken", data.accessToken);
+          } else {
+            sessionStorage.setItem("accessToken", data.accessToken);
           }
         } else {
           errorRef.current.innerText = data.message;

--- a/FE/src/components/SideBar/SideBar.js
+++ b/FE/src/components/SideBar/SideBar.js
@@ -62,6 +62,7 @@ function SideBar() {
               accessToken: "",
             }));
             localStorage.removeItem("accessToken");
+            sessionStorage.removeItem("accessToken");
           }}
         >
           로그아웃


### PR DESCRIPTION
## 요약

### 로그인 유지 박스 기능 추가
- 체크하지 않고 로그인 시 sessionStorage 저장
- 체크하고 로그인 시 localStorage 저장

### 회원가입 버튼 클릭 시 뷰 전환
- 로그인 모달에서 회원가입 모달로 뷰 전환

## 변경 사항

- 로그인 상태에서 새로고침했을 때 아예 로그아웃되는 것은 비정상 상황이므로, 새로고침시 로그인은 유지되도록 하되 로그인 유지를 원할 시 localStorage에 저장하여 창을 닫았다가 다시 접속해도 접속이 되도록 하고, 체크하지 않을 시 sessionStorage에 저장하여 창을 닫으면 로그아웃되도록 로직을 변경했습니다.
- 로그인 모달에서 회원가입 버튼을 클릭 시 회원가입 뷰로 전환되도록 클릭 이벤트를 추가하였습니다.

## 이슈 번호

close #142 