### PR TITLE
[Feat] 사용자 인증에 refresh token 도입

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@liaoliaots/nestjs-redis": "^9.0.5",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
@@ -23,6 +24,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "dotenv": "^16.3.1",
+        "ioredis": "^5.3.2",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.6.3",
         "passport": "^0.6.0",
@@ -862,7 +864,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -874,7 +876,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -990,6 +992,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1511,7 +1518,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1539,7 +1546,7 @@
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
@@ -1550,6 +1557,27 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@liaoliaots/nestjs-redis": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@liaoliaots/nestjs-redis/-/nestjs-redis-9.0.5.tgz",
+      "integrity": "sha512-nPcGLj0zW4mEsYtQYfWx3o7PmrMjuzFk6+t/g2IRopAeWWUZZ/5nIJ4KTKiz/3DJEUkbX8PZqB+dOhklGF0SVA==",
+      "dependencies": {
+        "tslib": "2.4.1"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0",
+        "ioredis": "^5.0.0"
+      }
+    },
+    "node_modules/@liaoliaots/nestjs-redis/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -1902,25 +1930,25 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.4",
@@ -2594,7 +2622,7 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2624,7 +2652,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
       "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2755,7 +2783,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3546,6 +3574,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3758,7 +3794,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -4096,7 +4132,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -5468,6 +5504,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6652,10 +6711,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -6772,7 +6841,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -7793,6 +7862,25 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -8407,6 +8495,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -8938,7 +9031,7 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9252,7 +9345,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9393,7 +9486,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
@@ -9785,7 +9878,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/BE/package.json
+++ b/BE/package.json
@@ -21,6 +21,7 @@
     "test:int": "cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --config ./test/jest-int.json"
   },
   "dependencies": {
+    "@liaoliaots/nestjs-redis": "^9.0.5",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
@@ -35,6 +36,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "dotenv": "^16.3.1",
+    "ioredis": "^5.3.2",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.6.3",
     "passport": "^0.6.0",

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -9,12 +9,20 @@ import { ShapesModule } from "./shapes/shapes.module";
 import { ShapesRepository } from "./shapes/shapes.repository";
 import { UsersRepository } from "./auth/users.repository";
 import { typeORMTestConfig } from "./configs/typeorm.test.config";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 @Module({
   imports: [
     TypeOrmModule.forRoot(
       process.env.NODE_ENV === "test" ? typeORMTestConfig : typeORMConfig,
     ),
+    RedisModule.forRoot({
+      readyLog: true,
+      config: {
+        host: "223.130.129.145",
+        port: 6379,
+      },
+    }),
     DiariesModule,
     AuthModule,
     IntroduceModule,

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -21,16 +21,16 @@ export class AuthController {
 
   @Post("/signin")
   @UseGuards(NoDuplicateLoginGuard)
-  signIn(
+  async signIn(
     @Body() authCredentialsDto: AuthCredentialsDto,
   ): Promise<AccessTokenDto> {
-    return this.authService.signIn(authCredentialsDto);
+    return await this.authService.signIn(authCredentialsDto);
   }
 
   @Post("/signout")
   @UseGuards(JwtAuthGuard)
   @HttpCode(204)
-  signOut(@GetUser() user: User): void {
-    this.authService.signOut(user);
+  async signOut(@GetUser() user: User): Promise<void> {
+    await this.authService.signOut(user);
   }
 }

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { AuthCredentialsDto } from "./dto/auth-credential.dto";
 import { AccessTokenDto } from "./dto/auth-access-token.dto";
-import { NoDuplicateLoginGuard } from "./guard/auth.user-guard";
+import { LogoutGuard, NoDuplicateLoginGuard } from "./guard/auth.user-guard";
 import { CreateUserDto } from "./dto/users.dto";
 import { User } from "./users.entity";
 import { GetUser } from "./get-user.decorator";
@@ -28,7 +28,7 @@ export class AuthController {
   }
 
   @Post("/signout")
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(LogoutGuard)
   @HttpCode(204)
   async signOut(@GetUser() user: User): Promise<void> {
     await this.authService.signOut(user);

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -2,7 +2,11 @@ import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { AuthCredentialsDto } from "./dto/auth-credential.dto";
 import { AccessTokenDto } from "./dto/auth-access-token.dto";
-import { LogoutGuard, NoDuplicateLoginGuard } from "./guard/auth.user-guard";
+import {
+  LogoutGuard,
+  NoDuplicateLoginGuard,
+  ReissueAccessTokenGuard as ReissueAccessTokenGuard,
+} from "./guard/auth.user-guard";
 import { CreateUserDto } from "./dto/users.dto";
 import { User } from "./users.entity";
 import { GetUser } from "./get-user.decorator";
@@ -32,5 +36,12 @@ export class AuthController {
   @HttpCode(204)
   async signOut(@GetUser() user: User): Promise<void> {
     await this.authService.signOut(user);
+  }
+
+  @Post("/reissue")
+  @UseGuards(ReissueAccessTokenGuard)
+  @HttpCode(201)
+  async reissueAccessToken(@GetUser() user: User): Promise<AccessTokenDto> {
+    return await this.authService.reissueAccessToken(user);
   }
 }

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -3,9 +3,8 @@ import { AuthService } from "./auth.service";
 import { AuthCredentialsDto } from "./dto/auth-credential.dto";
 import { AccessTokenDto } from "./dto/auth-access-token.dto";
 import {
-  LogoutGuard,
+  ExpiredOrNotGuard,
   NoDuplicateLoginGuard,
-  ReissueAccessTokenGuard as ReissueAccessTokenGuard,
 } from "./guard/auth.user-guard";
 import { CreateUserDto } from "./dto/users.dto";
 import { User } from "./users.entity";
@@ -32,14 +31,14 @@ export class AuthController {
   }
 
   @Post("/signout")
-  @UseGuards(LogoutGuard)
+  @UseGuards(ExpiredOrNotGuard)
   @HttpCode(204)
   async signOut(@GetUser() user: User): Promise<void> {
     await this.authService.signOut(user);
   }
 
   @Post("/reissue")
-  @UseGuards(ReissueAccessTokenGuard)
+  @UseGuards(ExpiredOrNotGuard)
   @HttpCode(201)
   async reissueAccessToken(@GetUser() user: User): Promise<AccessTokenDto> {
     return await this.authService.reissueAccessToken(user);

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -52,4 +52,15 @@ export class AuthService {
   async signOut(user: User): Promise<void> {
     await this.redisClient.del(user.userId);
   }
+
+  async reissueAccessToken(user: User): Promise<AccessTokenDto> {
+    const { userId } = user;
+    const payload = { userId };
+
+    const accessToken = await this.jwtService.sign(payload, {
+      expiresIn: "5m",
+    });
+
+    return new AccessTokenDto(accessToken);
+  }
 }

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -34,13 +34,13 @@ export class AuthService {
     if (await bcrypt.compare(password, user.password)) {
       const payload = { userId };
       const accessToken = await this.jwtService.sign(payload, {
-        expiresIn: "5m",
-      });
-      const refreshToken = await this.jwtService.sign(payload, {
         expiresIn: "1h",
       });
+      const refreshToken = await this.jwtService.sign(payload, {
+        expiresIn: "24h",
+      });
 
-      // refresh token의 expire time을 1시간으로 설정
+      // 86000s = 24h
       await this.redisClient.set(userId, refreshToken, "EX", 86400);
 
       return new AccessTokenDto(accessToken);
@@ -58,7 +58,7 @@ export class AuthService {
     const payload = { userId };
 
     const accessToken = await this.jwtService.sign(payload, {
-      expiresIn: "5m",
+      expiresIn: "1h",
     });
 
     return new AccessTokenDto(accessToken);

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
       });
 
       // refresh token의 expire time을 1시간으로 설정
-      this.redisClient.set(userId, refreshToken, "EX", 86400);
+      await this.redisClient.set(userId, refreshToken, "EX", 86400);
 
       return new AccessTokenDto(accessToken);
     } else {
@@ -49,7 +49,7 @@ export class AuthService {
     }
   }
 
-  signOut(user: User): void {
-    // const hasRefreshToken = true;
+  async signOut(user: User): Promise<void> {
+    await this.redisClient.del(user.userId);
   }
 }

--- a/BE/src/auth/guard/auth.jwt-guard.ts
+++ b/BE/src/auth/guard/auth.jwt-guard.ts
@@ -1,10 +1,14 @@
-import { Injectable, UnauthorizedException } from "@nestjs/common";
+import {
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { AuthGuard as NestAuthGuard } from "@nestjs/passport";
 
 @Injectable()
 export class JwtAuthGuard extends NestAuthGuard("jwt") {
   handleRequest(err, user, info: Error) {
-    if (err || !user) {
+    if (info && !user) {
       if (info.message === "No auth token") {
         throw new UnauthorizedException("비로그인 상태의 요청입니다.");
       } else if (info.message === "jwt expired") {
@@ -12,6 +16,17 @@ export class JwtAuthGuard extends NestAuthGuard("jwt") {
       }
       throw err || new UnauthorizedException("유효하지 않은 토큰입니다.");
     }
+
+    if (err && !user) {
+      if (err.message === "no refresh token") {
+        throw new ForbiddenException("로그인하지 않은 사용자입니다.");
+      } else if (err.message === "refresh expired") {
+        throw new ForbiddenException("리프레쉬 토큰이 만료되었습니다.");
+      }
+      throw new ForbiddenException("유효하지 않은 리프레쉬 토큰입니다.");
+    }
     return user;
   }
 }
+
+NestAuthGuard("jwt-");

--- a/BE/src/auth/guard/auth.user-guard.ts
+++ b/BE/src/auth/guard/auth.user-guard.ts
@@ -3,7 +3,9 @@ import {
   ConflictException,
   ExecutionContext,
   Injectable,
+  UnauthorizedException,
 } from "@nestjs/common";
+import { AuthGuard as NestAuthGuard } from "@nestjs/passport";
 import * as jwt from "jsonwebtoken";
 
 @Injectable()
@@ -25,5 +27,21 @@ export class NoDuplicateLoginGuard implements CanActivate {
     }
 
     throw new ConflictException("로그인 상태에서 다시 로그인할 수 없습니다.");
+  }
+}
+
+@Injectable()
+export class LogoutGuard extends NestAuthGuard("jwt") {
+  handleRequest(err, user, info: Error) {
+    if (err || !user) {
+      // 만료된 액세스 토큰으로 로그아웃 가능하도록 구현
+      if (info.message === "jwt expired") {
+        return user;
+      } else if (info.message === "No auth token") {
+        throw new UnauthorizedException("비로그인 상태의 요청입니다.");
+      }
+      throw err || new UnauthorizedException("유효하지 않은 토큰입니다.");
+    }
+    return user;
   }
 }

--- a/BE/src/auth/guard/auth.user-guard.ts
+++ b/BE/src/auth/guard/auth.user-guard.ts
@@ -55,3 +55,25 @@ export class LogoutGuard extends NestAuthGuard("jwt") {
     return user;
   }
 }
+
+@Injectable()
+export class ReissueAccessTokenGuard extends NestAuthGuard("jwt") {
+  handleRequest(err, user, info: Error) {
+    if (info && !user) {
+      if (info.message === "No auth token") {
+        throw new UnauthorizedException("비로그인 상태의 요청입니다.");
+      }
+    }
+
+    if (err && !user) {
+      if (err.message === "no refresh token") {
+        throw new ForbiddenException("로그인하지 않은 사용자입니다.");
+      } else if (err.message === "refresh expired") {
+        throw new ForbiddenException("리프레쉬 토큰이 만료되었습니다.");
+      }
+      throw new ForbiddenException("유효하지 않은 리프레쉬 토큰입니다.");
+    }
+
+    return user;
+  }
+}

--- a/BE/src/auth/guard/auth.user-guard.ts
+++ b/BE/src/auth/guard/auth.user-guard.ts
@@ -32,7 +32,7 @@ export class NoDuplicateLoginGuard implements CanActivate {
 }
 
 @Injectable()
-export class LogoutGuard extends NestAuthGuard("jwt") {
+export class ExpiredOrNotGuard extends NestAuthGuard("jwt") {
   handleRequest(err, user, info: Error) {
     if (info && !user) {
       if (info.message === "jwt expired") {
@@ -41,28 +41,6 @@ export class LogoutGuard extends NestAuthGuard("jwt") {
         throw new UnauthorizedException("비로그인 상태의 요청입니다.");
       }
       throw err || new UnauthorizedException("유효하지 않은 토큰입니다.");
-    }
-
-    if (err && !user) {
-      if (err.message === "no refresh token") {
-        throw new ForbiddenException("로그인하지 않은 사용자입니다.");
-      } else if (err.message === "refresh expired") {
-        throw new ForbiddenException("리프레쉬 토큰이 만료되었습니다.");
-      }
-      throw new ForbiddenException("유효하지 않은 리프레쉬 토큰입니다.");
-    }
-
-    return user;
-  }
-}
-
-@Injectable()
-export class ReissueAccessTokenGuard extends NestAuthGuard("jwt") {
-  handleRequest(err, user, info: Error) {
-    if (info && !user) {
-      if (info.message === "No auth token") {
-        throw new UnauthorizedException("비로그인 상태의 요청입니다.");
-      }
     }
 
     if (err && !user) {

--- a/BE/test/int/auth.reissue.int-spec.ts
+++ b/BE/test/int/auth.reissue.int-spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { ValidationPipe } from "@nestjs/common";
+import { AuthModule } from "src/auth/auth.module";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { User } from "src/auth/users.entity";
+import { UsersRepository } from "src/auth/users.repository";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
+
+describe("[액세스 토큰 재발급] /auth/reissue POST 통합 테스트", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        AuthModule,
+      ],
+      providers: [UsersRepository],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
+    await app.init();
+
+    await request(app.getHttpServer())
+      .post("/auth/signup")
+      .send({
+        userId: "SignoutTestUserId",
+        password: "SignoutTestPassword",
+        email: "signouttestemail@naver.com",
+        nickname: "SignoutTestUser",
+      })
+      .expect(204);
+  });
+
+  afterAll(async () => {
+    const usersRepository = new UsersRepository();
+
+    const testUser = await usersRepository.getUserByUserId("SignoutTestUserId");
+    if (testUser) {
+      await User.remove(testUser);
+    }
+
+    await app.close();
+  });
+
+  it("올바른 토큰으로 요청 시 201 Created 응답", async () => {
+    const signInResponse = await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "SignoutTestUserId",
+        password: "SignoutTestPassword",
+      })
+      .expect(201);
+
+    expect(signInResponse.body).toHaveProperty("accessToken");
+
+    const { accessToken } = signInResponse.body;
+
+    await request(app.getHttpServer())
+      .post("/auth/reissue")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(201);
+  });
+
+  it("유효하지 않은 액세스 토큰이 포함된 상태로 로그아웃 요청 시 401 Unauthorized 응답", async () => {
+    await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "SignoutTestUserId",
+        password: "SignoutTestPassword",
+      })
+      .expect(201);
+
+    const invalidAccessToken = "1234";
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/reissue")
+      .set("Authorization", `Bearer ${invalidAccessToken}`)
+      .expect(401);
+
+    expect(postResponse.body).toEqual({
+      error: "Unauthorized",
+      message: "유효하지 않은 토큰입니다.",
+      statusCode: 401,
+    });
+  });
+
+  it("토큰이 존재하지 않은 상태로 로그아웃 요청 시 401 Unauthorized 응답", async () => {
+    await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "SignoutTestUserId",
+        password: "SignoutTestPassword",
+      })
+      .expect(201);
+
+    const postResponse = await request(app.getHttpServer())
+      .post("/auth/reissue")
+      .expect(401);
+
+    expect(postResponse.body).toEqual({
+      error: "Unauthorized",
+      message: "비로그인 상태의 요청입니다.",
+      statusCode: 401,
+    });
+  });
+});

--- a/BE/test/int/auth.signin.int-spec.ts
+++ b/BE/test/int/auth.signin.int-spec.ts
@@ -5,13 +5,24 @@ import { ValidationPipe } from "@nestjs/common";
 import { AuthModule } from "src/auth/auth.module";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[로그인] /auth/signin POST 통합 테스트", () => {
   let app: INestApplication;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TypeOrmModule.forRoot(typeORMTestConfig), AuthModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        AuthModule,
+      ],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/BE/test/int/auth.signout.int-spec.ts
+++ b/BE/test/int/auth.signout.int-spec.ts
@@ -7,13 +7,24 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { User } from "src/auth/users.entity";
 import { UsersRepository } from "src/auth/users.repository";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[로그아웃] /auth/signout POST 통합 테스트", () => {
   let app: INestApplication;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TypeOrmModule.forRoot(typeORMTestConfig), AuthModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        AuthModule,
+      ],
       providers: [UsersRepository],
     }).compile();
 
@@ -31,7 +42,7 @@ describe("[로그아웃] /auth/signout POST 통합 테스트", () => {
         email: "signouttestemail@naver.com",
         nickname: "SignoutTestUser",
       })
-      .expect(201);
+      .expect(204);
   });
 
   afterAll(async () => {

--- a/BE/test/int/auth.signup.int-spec.ts
+++ b/BE/test/int/auth.signup.int-spec.ts
@@ -1,20 +1,29 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { AuthModule } from "src/auth/auth.module";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
-import { typeORMConfig } from "src/configs/typeorm.config";
 import { User } from "src/auth/users.entity";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[회원가입] /auth/signup POST 통합 테스트", () => {
   let app: INestApplication;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TypeOrmModule.forRoot(typeORMTestConfig), AuthModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        AuthModule,
+      ],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/BE/test/int/diaries.create.int-spec.ts
+++ b/BE/test/int/diaries.create.int-spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[일기 작성] /diaries POST 통합 테스트", () => {
   let app: INestApplication;
@@ -13,7 +13,17 @@ describe("[일기 작성] /diaries POST 통합 테스트", () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TypeOrmModule.forRoot(typeORMTestConfig), DiariesModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        DiariesModule,
+      ],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/BE/test/int/diaries.delete.int-spec.ts
+++ b/BE/test/int/diaries.delete.int-spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[일기 삭제] /diaries/:uuid DELETE 통합 테스트", () => {
   let app: INestApplication;
@@ -14,7 +14,17 @@ describe("[일기 삭제] /diaries/:uuid DELETE 통합 테스트", () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TypeOrmModule.forRoot(typeORMTestConfig), DiariesModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        DiariesModule,
+      ],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/BE/test/int/diaries.read-list.int-spec.ts
+++ b/BE/test/int/diaries.read-list.int-spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../../src/app.module";
 import { ValidationPipe } from "@nestjs/common";
 import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[전체 일기 조회] /diaries GET 통합 테스트", () => {
   let app: INestApplication;
@@ -13,7 +13,17 @@ describe("[전체 일기 조회] /diaries GET 통합 테스트", () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [TypeOrmModule.forRoot(typeORMTestConfig), DiariesModule],
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        DiariesModule,
+      ],
     }).compile();
 
     app = moduleFixture.createNestApplication();

--- a/BE/test/int/diaries.read.int-spec.ts
+++ b/BE/test/int/diaries.read.int-spec.ts
@@ -7,6 +7,7 @@ import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ShapesModule } from "src/shapes/shapes.module";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[일기 조회] /diaries/:uuid GET 통합 테스트", () => {
   let app: INestApplication;
@@ -19,6 +20,13 @@ describe("[일기 조회] /diaries/:uuid GET 통합 테스트", () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
         DiariesModule,
         ShapesModule,
       ],

--- a/BE/test/int/diaries.update.int-spec.ts
+++ b/BE/test/int/diaries.update.int-spec.ts
@@ -7,6 +7,7 @@ import { DiariesModule } from "src/diaries/diaries.module";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ShapesModule } from "src/shapes/shapes.module";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
 
 describe("[일기 수정] /diaries PUT 통합 테스트", () => {
   let app: INestApplication;
@@ -19,6 +20,13 @@ describe("[일기 수정] /diaries PUT 통합 테스트", () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
         DiariesModule,
         ShapesModule,
       ],


### PR DESCRIPTION
## 요약

- Redis를 도입하여 사용자 인증에 refresh token 적용
- 액세스 토큰 재발급 API 구현

## 변경 사항

### Redis를 도입하여 사용자 인증에 refresh token 적용
- 로그인 시 리프레쉬 토큰을 발급하여 Redis에 저장함
  - 키 값은 해당 사용자의 유저 아이디로 정함
- 로그아웃 시 Redis에 저장된 리프레쉬 토큰을 삭제함
  - 로그아웃 및 액세스 토큰 재발급 시 사용하는 ExpiredOrNotGuard 구현
    - JwtAuthGuard와 거의 동일하나 만료된 액세스 토큰일 때에도 정상 요청하도록 수정   
- Diary, Shape 등 사용자 인증이 필요한 요청에 리프레쉬 토큰 인증 과정을 추가함
  - JwtStrategy에서, 현재 서버가 해당 사용자에 대한 적절한 리프레쉬 토큰을 저장하고 있는지 검증함
  - JwtAuthGuard에서, 리프레쉬 토큰 예외 사항에 대해 403 Forbidden을 throw하도록 함
  

### 액세스 토큰 재발급 API 구현
- /auth/reissue POST 요청으로 액세스 토큰을 재발급 받는 API 구현
  - 정상 요청 시 201 Created 응답으로 Body에 액세스 토큰을 담아 응답함
  - 유효하지 않은 액세스 토큰을 사용하거나 액세스 토큰이 존재하지 않는 요청의 경우 401 Unauthorized를 응답함
  - 비정상적인 리프레쉬 토큰의 경우 403 Forbidden을 응답함
- 액세스 토큰 재발급 API에 대한 통합 테스트를 작성


## 참고 사항

- 추후 프로젝트를 Dockerize할 때 Redis와의 통신이 정상적으로 이루어지는지 검증 필요함

## 이슈 번호

close #145 
