### PR TITLE
[Hotfix] privateDiaryGuard 생성자 오류 수정

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -19,8 +19,8 @@ import { RedisModule } from "@liaoliaots/nestjs-redis";
     RedisModule.forRoot({
       readyLog: true,
       config: {
-        host: "223.130.129.145",
-        port: 6379,
+        host: process.env.REDIS_HOST,
+        port: Number(process.env.REDIS_PORT),
       },
     }),
     DiariesModule,

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { JwtModule } from "@nestjs/jwt";
@@ -9,6 +9,7 @@ import { PrivateDiaryGuard } from "./guard/auth.diary-guard";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "./users.entity";
 import { UsersRepository } from "./users.repository";
+import { DiariesRepository } from "src/diaries/diaries.repository";
 
 @Module({
   imports: [
@@ -22,7 +23,13 @@ import { UsersRepository } from "./users.repository";
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, UsersRepository, PrivateDiaryGuard],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    UsersRepository,
+    PrivateDiaryGuard,
+    DiariesRepository,
+  ],
   exports: [PassportModule, UsersRepository],
 })
 export class AuthModule {}

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { Module, forwardRef } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { JwtModule } from "@nestjs/jwt";

--- a/BE/src/auth/guard/auth.diary-guard.ts
+++ b/BE/src/auth/guard/auth.diary-guard.ts
@@ -11,8 +11,8 @@ import { InjectRedis } from "@liaoliaots/nestjs-redis";
 @Injectable()
 export class PrivateDiaryGuard extends JwtAuthGuard {
   constructor(
-    private readonly diariesRepository: DiariesRepository,
     @InjectRedis() protected readonly redisClient: Redis,
+    private readonly diariesRepository: DiariesRepository,
   ) {
     super(redisClient);
   }


### PR DESCRIPTION
## 요약

- privateDiaryGuard가 jwtAuthGuard의 수정으로 인해 변경된 부분을 제대로 반영

## 변경 사항

### privateDiaryGuard가 jwtAuthGuard의 수정으로 인해 변경된 부분을 제대로 반영
- jwtAuthGuard의 생성자가 redisClient를 받기 때문에, privateDiaryGuard의 생성자의 파라미터의 순서가 redisClient, diariesRepository 순으로 되어있어야 했다.
- AuthModule의 provider에 DiariesRepository를 넣지 않으면, AuthModule만 import하여 테스트를 진행할 때 DiariesRepository를 사용할 수 없는 문제가 발생했다. 따라서 이를 수정했다. 

## 참고 사항

- 없음
 
## 이슈 번호
close #150 
- 관련된 이슈 번호를 close 뒤에 붙여주세요.
<!-- ex) close #1 -->
