### PR TITLE
[Hotfix] Shape 엔티티의 user에 eager loading 추가

### DIFF
--- a/BE/src/shapes/shapes.entity.ts
+++ b/BE/src/shapes/shapes.entity.ts
@@ -21,7 +21,10 @@ export class Shape extends BaseEntity {
   @Generated("uuid")
   uuid: string;
 
-  @ManyToOne(() => User, (user) => user.userId, { nullable: false })
+  @ManyToOne(() => User, (user) => user.userId, {
+    nullable: false,
+    eager: true,
+  })
   user: User;
 
   @Column()


### PR DESCRIPTION
## 요약

- Shape 엔티티의 user에 eager: true로 설정

## 변경 사항

### Shape 엔티티의 user에 eager: true로 설정
- Shape 엔티티의 user가 lazy loading 되어 getShapeByUuid로 읽어온 Shape의 user의 userId를 읽지 못하는 문제가 발생하여 수정함.

## 참고 사항

- 없음

## 이슈 번호

없음
