### PR TITLE
[Feat] history API 활용하여 이전, 이후 페이지 이동 구현

### DIFF
--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -1,8 +1,11 @@
-import React, { useLayoutEffect } from "react";
+/* eslint-disable no-unused-vars */
+
+import React, { useEffect, useLayoutEffect } from "react";
 import Reset from "styled-reset";
 import { createGlobalStyle } from "styled-components";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import userAtom from "./atoms/userAtom";
+import diaryAtom from "./atoms/diaryAtom";
 import Header from "./components/Header/Header";
 import HomePage from "./pages/HomePage";
 import MainPage from "./pages/MainPage";
@@ -36,6 +39,7 @@ const GlobalStyle = createGlobalStyle`
 
 function App() {
   const [userState, setUserState] = useRecoilState(userAtom);
+  const setDiaryState = useSetRecoilState(diaryAtom);
 
   useLayoutEffect(() => {
     let accessToken = localStorage.getItem("accessToken");
@@ -43,6 +47,20 @@ function App() {
     if (accessToken) {
       setUserState({ ...userState, isLogin: true, accessToken });
     }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("beforeunload", (e) => {
+      e.preventDefault();
+      e.returnValue = "";
+    });
+
+    window.onpopstate = (event) => {
+      console.log(event.state);
+      if (event.state) {
+        setDiaryState(event.state);
+      }
+    };
   }, []);
 
   return (

--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -56,7 +56,6 @@ function App() {
     });
 
     window.onpopstate = (event) => {
-      console.log(event.state);
       if (event.state) {
         setDiaryState(event.state);
       }

--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -50,11 +50,6 @@ function App() {
   }, []);
 
   useEffect(() => {
-    window.addEventListener("beforeunload", (e) => {
-      e.preventDefault();
-      e.returnValue = "";
-    });
-
     window.onpopstate = (event) => {
       if (event.state) {
         setDiaryState(event.state);

--- a/FE/src/atoms/diaryAtom.js
+++ b/FE/src/atoms/diaryAtom.js
@@ -11,6 +11,12 @@ const diaryAtom = atom({
     diaryUuid: "",
     isLoaded: false,
   },
+  effects: [
+    ({ onSet }) =>
+      onSet((newDiaryState) => {
+        console.log(newDiaryState);
+      }),
+  ],
 });
 
 export default diaryAtom;

--- a/FE/src/atoms/diaryAtom.js
+++ b/FE/src/atoms/diaryAtom.js
@@ -11,12 +11,6 @@ const diaryAtom = atom({
     diaryUuid: "",
     isLoaded: false,
   },
-  effects: [
-    ({ onSet }) =>
-      onSet((newDiaryState) => {
-        console.log(newDiaryState);
-      }),
-  ],
 });
 
 export default diaryAtom;

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -23,7 +23,10 @@ function DiaryCreateModal() {
   const setDiaryState = useSetRecoilState(diaryAtom);
 
   const closeModal = () => {
-    setDiaryState((prev) => ({ ...prev, isCreate: false }));
+    setDiaryState((prev) => ({
+      ...prev,
+      isCreate: false,
+    }));
   };
 
   const addTag = (e) => {

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useMutation, useQuery } from "react-query";
 import styled from "styled-components";
@@ -24,6 +24,19 @@ function DiaryCreateModal() {
   const [newShapeData, setNewShapeData] = useState(null);
   const userState = useRecoilValue(userAtom);
   const setDiaryState = useSetRecoilState(diaryAtom);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
 
   const closeModal = () => {
     setDiaryState((prev) => ({

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -381,7 +381,6 @@ const DiaryModalContentInputBox = styled.textarea`
 
   resize: none;
 
-  word_wrap: break-word;
   word-break: break-all;
 
   &::placeholder {

--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -47,11 +47,7 @@ function DiaryDeleteModal() {
               diaryUuid: diaryState.diaryUuid,
               accessToken: userState.accessToken,
             });
-            setDiaryState((prev) => ({
-              ...prev,
-              isRead: false,
-              isDelete: false,
-            }));
+            window.history.back();
           }}
         >
           확인

--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -106,11 +106,22 @@ function DiaryListModal() {
             src={zoomIn}
             alt='zoom-in'
             onClick={() => {
-              setDiaryState((prev) => ({
-                ...prev,
-                isRead: true,
-                isList: false,
-              }));
+              setDiaryState((prev) => {
+                window.history.pushState(
+                  {
+                    ...prev,
+                    isRead: true,
+                    isList: false,
+                  },
+                  "",
+                  "",
+                );
+                return {
+                  ...prev,
+                  isRead: true,
+                  isList: false,
+                };
+              });
             }}
           />
         </DiaryTitle>

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -79,11 +79,22 @@ function DiaryReadModal() {
         <DiaryModalTitle>{data.title}</DiaryModalTitle>
         <DiaryButton
           onClick={() => {
-            setDiaryState((prev) => ({
-              ...prev,
-              isRead: false,
-              isUpdate: true,
-            }));
+            setDiaryState((prev) => {
+              window.history.pushState(
+                {
+                  ...prev,
+                  isRead: false,
+                  isUpdate: true,
+                },
+                "",
+                "",
+              );
+              return {
+                ...prev,
+                isRead: false,
+                isUpdate: true,
+              };
+            });
           }}
         >
           <img

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -353,7 +353,6 @@ const DiaryModalContentInputBox = styled.textarea`
 
   resize: none;
 
-  word_wrap: break-word;
   word-break: break-all;
 
   &::placeholder {

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useRecoilValue } from "recoil";
 import { useMutation, useQuery } from "react-query";
 import styled from "styled-components";
@@ -54,6 +54,18 @@ function DiaryUpdateModal() {
     shapeUuid: "cf3a074a-0707-40c4-a598-c7c17a654476",
     uuid: diaryState.diaryUuid,
   });
+
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
 
   const closeModal = () => {
     window.history.back();

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { useRecoilValue, useRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import { useMutation, useQuery } from "react-query";
 import styled from "styled-components";
 import userAtom from "../../atoms/userAtom";
@@ -44,7 +44,7 @@ function DiaryUpdateModal() {
   const contentRef = useRef(null);
   const [isInput, setIsInput] = React.useState(true);
   const userState = useRecoilValue(userAtom);
-  const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
+  const diaryState = useRecoilValue(diaryAtom);
   const [diaryData, setDiaryData] = React.useState({
     title: "test",
     content: "test",
@@ -56,7 +56,7 @@ function DiaryUpdateModal() {
   });
 
   const closeModal = () => {
-    setDiaryState((prev) => ({ ...prev, isUpdate: false }));
+    window.history.back();
   };
 
   const addTag = (e) => {

--- a/FE/src/components/SideBar/SideBar.js
+++ b/FE/src/components/SideBar/SideBar.js
@@ -21,11 +21,18 @@ function SideBar() {
                 ...prev,
                 isSideBar: false,
               }));
-              setDiaryState((prev) => ({
-                ...prev,
-                isRead: false,
-                isList: false,
-              }));
+              setDiaryState((prev) => {
+                window.history.pushState(
+                  { ...prev, isRead: false, isList: false },
+                  "",
+                  "",
+                );
+                return {
+                  ...prev,
+                  isRead: false,
+                  isList: false,
+                };
+              });
             }}
           >
             일기 쓰기
@@ -36,11 +43,25 @@ function SideBar() {
                 ...prev,
                 isSideBar: false,
               }));
-              setDiaryState({
-                isCreate: false,
-                isRead: false,
-                isDelete: false,
-                isList: true,
+              setDiaryState((prev) => {
+                window.history.pushState(
+                  {
+                    ...prev,
+                    isCreate: false,
+                    isRead: false,
+                    isUpdate: false,
+                    isList: true,
+                  },
+                  "",
+                  "",
+                );
+                return {
+                  ...prev,
+                  isCreate: false,
+                  isRead: false,
+                  isUpdate: false,
+                  isList: true,
+                };
               });
             }}
           >

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -6,11 +6,9 @@ import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
-    <QueryClientProvider client={new QueryClient()}>
-      <RecoilRoot>
-        <App />
-      </RecoilRoot>
-    </QueryClientProvider>
-  </React.StrictMode>,
+  <QueryClientProvider client={new QueryClient()}>
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
+  </QueryClientProvider>,
 );

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useRecoilState } from "recoil";
 import diaryAtom from "../atoms/diaryAtom";
@@ -12,12 +12,32 @@ import DiaryLoadingModal from "../components/DiaryModal/DiaryLoadingModal";
 function MainPage() {
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
 
+  useEffect(() => {
+    setDiaryState((prev) => {
+      const newState = {
+        ...prev,
+        isCreate: false,
+        isRead: false,
+        isUpdate: false,
+        isList: false,
+      };
+      window.history.pushState(newState, "", "");
+      return newState;
+    });
+  }, []);
+
   return (
     <>
       <MainPageWrapper
         onClick={(e) => {
           e.preventDefault();
-          setDiaryState((prev) => ({ ...prev, isCreate: true, isRead: false }));
+          setDiaryState((prev) => ({
+            ...prev,
+            isCreate: true,
+            isRead: false,
+            isUpdate: false,
+            isList: false,
+          }));
         }}
       />
       {diaryState.isCreate ? <DiaryCreateModal /> : null}


### PR DESCRIPTION
## 요약

### 뒤로가기, 앞으로가기 이동 구현
- history API 활용

## 변경 사항

- 페이지 이동을 쉽게 할 수 있도록 구현하였습니다.
  - diaryAtom 상태가 바뀔 때마다 history에 pushState하여 기록하고, 이전 버튼이나 이후 버튼을 눌러 popState될 때마다 그 기록을 탐색해 diaryAtom을 변화시키면서 페이지를 변화시키도록 구현
  - 삭제 모달, 리스트 뷰의 세부적인 모달 등등에 대해서는 페이지 이동 처리하는 것이 부자연스러우므로 처리하지 않음
- 추가적으로, 생성 혹은 수정하고 있을 시 새로고침이나 다른 페이지로 이동할 때 변경사항이 저장되지 않을 수 있다는 경고 문구를 출력하도록 구현하였습니다.

<img width="1680" alt="스크린샷 2023-11-28 오후 5 51 17" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023654/c9c7d2bd-d03e-4ef8-98b5-e382a92df606">

## 참고 사항

- 삭제나 수정 등등 작업이 끝난 후 뒤로 이동하게 될 때 최신 정보로 업데이트가 되지 않는 현상이 있음. 수정이 필요함.

## 이슈 번호

close #148 
