### PR TITLE
[Feat] 모양 목록 API 구현

### DIFF
--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -38,4 +38,10 @@ export class ShapesController {
       );
     }
   }
+
+  @Get("/")
+  @UseGuards(JwtAuthGuard)
+  async getShapesByUser(@GetUser() user: User): Promise<string[]> {
+    return await this.shapesService.getShapesByUser(user);
+  }
 }

--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -26,7 +26,21 @@ export class ShapesController {
 
   @Get("/")
   @UseGuards(JwtAuthGuard)
-  async getShapesByUser(@GetUser() user: User): Promise<string[]> {
-    return await this.shapesService.getShapesByUser(user);
+  async getShapesByUser(@GetUser() user: User): Promise<object> {
+    const shapeLists = await this.shapesService.getShapesByUser(user);
+    const shapeUuidList = shapeLists[0];
+    const shapeFileList = shapeLists[1];
+
+    let result = {};
+
+    for (let i = 0; i < shapeUuidList.length; i++) {
+      const response = {
+        uuid: shapeUuidList[i],
+        svg: shapeFileList[i],
+      };
+      result[`shape${i + 1}`] = response;
+    }
+
+    return result;
   }
 }

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -31,4 +31,11 @@ export class ShapesRepository {
     }
     return found;
   }
+
+  async getShapesByUser(user: User): Promise<Shape[]> {
+    const shapeList = await Shape.find({
+      where: { user: { userId: user.userId } },
+    });
+    return shapeList;
+  }
 }

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -36,6 +36,9 @@ export class ShapesRepository {
     let shapeList: Shape[] = await Shape.find({
       where: { user: { userId: user.userId } },
     });
+    if (!shapeList) {
+      throw new NotFoundException("존재하지 않는 사용자입니다.");
+    }
 
     // 기본 모양 추가
     if (user.userId !== "commonUser") {

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -33,9 +33,20 @@ export class ShapesRepository {
   }
 
   async getShapesByUser(user: User): Promise<Shape[]> {
-    const shapeList = await Shape.find({
+    let shapeList = await Shape.find({
       where: { user: { userId: user.userId } },
     });
+
+    // 기본 모양 추가
+    if (user.userId !== "commonUser") {
+      const commonUser = await User.findOne({
+        where: { userId: "commonUser" },
+      });
+      shapeList = await Shape.find({
+        where: { user: { userId: commonUser.userId } },
+      });
+    }
+
     return shapeList;
   }
 }

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -40,19 +40,6 @@ export class ShapesRepository {
       throw new NotFoundException("존재하지 않는 사용자입니다.");
     }
 
-    // 기본 모양 추가
-    if (user.userId !== "commonUser") {
-      const commonUser = await User.findOne({
-        where: { userId: "commonUser" },
-      });
-
-      shapeList.concat(
-        await Shape.find({
-          where: { user: { userId: commonUser.userId } },
-        }),
-      );
-    }
-
     return shapeList;
   }
 }

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -33,7 +33,7 @@ export class ShapesRepository {
   }
 
   async getShapesByUser(user: User): Promise<Shape[]> {
-    let shapeList = await Shape.find({
+    let shapeList: Shape[] = await Shape.find({
       where: { user: { userId: user.userId } },
     });
 
@@ -42,9 +42,12 @@ export class ShapesRepository {
       const commonUser = await User.findOne({
         where: { userId: "commonUser" },
       });
-      shapeList = await Shape.find({
-        where: { user: { userId: commonUser.userId } },
-      });
+
+      shapeList.concat(
+        await Shape.find({
+          where: { user: { userId: commonUser.userId } },
+        }),
+      );
     }
 
     return shapeList;

--- a/BE/src/shapes/shapes.repository.ts
+++ b/BE/src/shapes/shapes.repository.ts
@@ -33,7 +33,7 @@ export class ShapesRepository {
   }
 
   async getShapesByUser(user: User): Promise<Shape[]> {
-    let shapeList: Shape[] = await Shape.find({
+    const shapeList: Shape[] = await Shape.find({
       where: { user: { userId: user.userId } },
     });
     if (!shapeList) {

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -29,18 +29,29 @@ export class ShapesService {
     return getShapeFromS3(shape.shapePath);
   }
 
-  async getShapesByUser(user: User): Promise<string[]> {
+  async getShapesByUser(user: User): Promise<string[][]> {
+    let shapeList = [];
     const defaultShapeList = await this.getDefaultShapeFiles();
-    const shapeList = defaultShapeList.concat(
-      await this.shapesRepository.getShapesByUser(user),
-    );
 
-    const shapeArray = await Promise.all(
-      shapeList.map((shape) => {
-        return shape.uuid;
+    if (user.userId !== "commonUser") {
+      shapeList = defaultShapeList.concat(
+        await this.shapesRepository.getShapesByUser(user),
+      );
+    } else {
+      shapeList = defaultShapeList;
+    }
+
+    const shapeUuidList = shapeList.map((shape) => {
+      return shape.uuid;
+    });
+
+    // getShapeFileByUuid가 async라서 Promise.all로 await을 걸지 않으면 Promise<string[]>이 반환
+    const shapeFileList = await Promise.all(
+      shapeUuidList.map((uuid) => {
+        return this.getShapeFileByUuid(uuid, user);
       }),
     );
 
-    return shapeArray;
+    return [shapeUuidList, shapeFileList];
   }
 }

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -28,4 +28,17 @@ export class ShapesService {
     }
     return getFileFromS3(shape.shapePath);
   }
+
+  async getShapesByUser(user: User): Promise<string[]> {
+    const shapeList = await this.shapesRepository.getShapesByUser(user);
+    const shapeArray = [];
+
+    await Promise.all(
+      shapeList.map((shape) => {
+        shapeArray.push(shape.uuid);
+      }),
+    );
+
+    return shapeArray;
+  }
 }

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -30,12 +30,14 @@ export class ShapesService {
   }
 
   async getShapesByUser(user: User): Promise<string[]> {
-    const shapeList = await this.shapesRepository.getShapesByUser(user);
-    const shapeArray = [];
+    const defaultShapeList = await this.getDefaultShapeFiles();
+    const shapeList = defaultShapeList.concat(
+      await this.shapesRepository.getShapesByUser(user),
+    );
 
-    await Promise.all(
+    const shapeArray = await Promise.all(
       shapeList.map((shape) => {
-        shapeArray.push(shape.uuid);
+        return shape.uuid;
       }),
     );
 

--- a/BE/test/int/shape.read-list.int-spec.ts
+++ b/BE/test/int/shape.read-list.int-spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { ValidationPipe } from "@nestjs/common";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
+import { ShapesModule } from "src/shapes/shapes.module";
+
+describe("[전체 모양 조회] /shapes GET 통합 테스트", () => {
+  let app: INestApplication;
+  let accessToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        ShapesModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
+    await app.init();
+
+    const signInPost = await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "commonUser",
+        password: process.env.COMMON_USER_PASS,
+      });
+
+    accessToken = signInPost.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("정상 요청 시 200 OK 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .get("/shapes")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(postResponse.body).toEqual([
+      "0c99bbc6-e404-464b-a310-5bf0fa0f0fa7",
+      "d4ffa969-a299-4e15-a700-dccd6ef89f25",
+      "acbb06cb-a6bf-4f3b-9f30-f59ad5c03c90",
+    ]);
+  });
+
+  it("액세스 토큰 없이 요청 시 401 Unauthorized 응답", async () => {
+    const postResponse = await request(app.getHttpServer())
+      .get("/shapes")
+      .expect(401);
+
+    expect(postResponse.body).toEqual({
+      error: "Unauthorized",
+      message: "비로그인 상태의 요청입니다.",
+      statusCode: 401,
+    });
+  });
+});

--- a/BE/test/int/shape.read-list.int-spec.ts
+++ b/BE/test/int/shape.read-list.int-spec.ts
@@ -59,6 +59,28 @@ describe("[전체 모양 조회] /shapes GET 통합 테스트", () => {
     ]);
   });
 
+  it("일반 유저 정상 요청 시 200 OK 응답", async () => {
+    const signInPost = await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "userId",
+        password: "password",
+      });
+
+    accessToken = signInPost.body.accessToken;
+
+    const postResponse = await request(app.getHttpServer())
+      .get("/shapes")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(postResponse.body).toEqual([
+      "0c99bbc6-e404-464b-a310-5bf0fa0f0fa7",
+      "d4ffa969-a299-4e15-a700-dccd6ef89f25",
+      "acbb06cb-a6bf-4f3b-9f30-f59ad5c03c90",
+    ]);
+  });
+
   it("액세스 토큰 없이 요청 시 401 Unauthorized 응답", async () => {
     const postResponse = await request(app.getHttpServer())
       .get("/shapes")


### PR DESCRIPTION
## 요약

- 현재 사용자가 사용하는 모든 모양을 목록으로 만들어 응답하는 모양 목록 API 구현
- 모양 목록 API 통합 테스트 코드 작성

## 변경 사항

### 현재 사용자가 사용하는 모든 모양을 목록으로 만들어 응답하는 모양 목록 API 구현
- 액세스 토큰을 통해 현재 사용자를 읽어오고, 해당 사용자가 사용하는 모든 모양을 배열에 담아 응답
- commonUser가 가지고 있는 기본 모양도 배열에 포함시켜서 응답하도록 함

### 모양 목록 API 통합 테스트 코드 작성
- 정상 요청 시 모양 uuid가 담긴 배열을 담아 200 OK 응답
- commonUser가 아닌 다른 유저가 정상 요청 시 commonUser의 모양을 읽어오는지 테스트
- 액세스 토큰 없이 요청 시 401 Unauthorized 응답

## 참고 사항

### 수행 결과

모양 목록 정상 요청
![모양 목록 정상](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/363602eb-062d-4d08-a7ac-027535aabe61)


## 이슈 번호

close #156
