### PR TITLE
[Feat] 메인 페이지 3D뷰 구현 및 API 연동

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fe",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/drei": "^9.88.17",
         "@react-three/fiber": "^8.15.10",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -20,6 +21,7 @@
         "styled-components": "^6.1.1",
         "styled-reset": "^4.5.1",
         "three": "^0.158.0",
+        "three.js": "^0.77.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3188,6 +3190,11 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.8.tgz",
+      "integrity": "sha512-Rp7ll8BHrKB3wXaRFKhrltwZl1CiXGdibPxuWXvqGnKTnv8fqa/nvftYNuSbf+pbJWKYCXdBtYTITdAUTGGh0Q=="
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3345,6 +3352,128 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.6.1.tgz",
+      "integrity": "sha512-ls/rJBrAqiAYozjLo5EPPLLOb1LM0lNVQcXODTC1SMtS6DbuBCPaKco5svFUQFMP2dso3O+qcC4k9FsKc0KxMQ==",
+      "dependencies": {
+        "@react-spring/shared": "~9.6.1",
+        "@react-spring/types": "~9.6.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.6.1.tgz",
+      "integrity": "sha512-3HAAinAyCPessyQNNXe5W0OHzRfa8Yo5P748paPcmMowZ/4sMfaZ2ZB6e5x5khQI8NusOHj8nquoutd6FRY5WQ==",
+      "dependencies": {
+        "@react-spring/animated": "~9.6.1",
+        "@react-spring/rafz": "~9.6.1",
+        "@react-spring/shared": "~9.6.1",
+        "@react-spring/types": "~9.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.6.1.tgz",
+      "integrity": "sha512-v6qbgNRpztJFFfSE3e2W1Uz+g8KnIBs6SmzCzcVVF61GdGfGOuBrbjIcp+nUz301awVmREKi4eMQb2Ab2gGgyQ=="
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.6.1.tgz",
+      "integrity": "sha512-PBFBXabxFEuF8enNLkVqMC9h5uLRBo6GQhRMQT/nRTnemVENimgRd+0ZT4yFnAQ0AxWNiJfX3qux+bW2LbG6Bw==",
+      "dependencies": {
+        "@react-spring/rafz": "~9.6.1",
+        "@react-spring/types": "~9.6.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.6.1.tgz",
+      "integrity": "sha512-Tyw2YhZPKJAX3t2FcqvpLRb71CyTe1GvT3V+i+xJzfALgpk10uPGdGaQQ5Xrzmok1340DAeg2pR/MCfaW7b8AA==",
+      "dependencies": {
+        "@react-spring/animated": "~9.6.1",
+        "@react-spring/core": "~9.6.1",
+        "@react-spring/shared": "~9.6.1",
+        "@react-spring/types": "~9.6.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.6.1.tgz",
+      "integrity": "sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q=="
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.88.17",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.88.17.tgz",
+      "integrity": "sha512-WEYAkikzw0juG3F1aMy1AEeuRmsGmKytb8ETZARd4E6Q61Z1ceoL7fRvrnrXE/A2MHKgSzJgkckMEhKlbbJlyw==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@mediapipe/tasks-vision": "0.10.8",
+        "@react-spring/three": "~9.6.1",
+        "@use-gesture/react": "^10.2.24",
+        "camera-controls": "^2.4.2",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.28",
+        "glsl-noise": "^0.0.0",
+        "lodash.clamp": "^4.0.3",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "maath": "^0.9.0",
+        "meshline": "^3.1.6",
+        "react-composer": "^5.0.3",
+        "react-merge-refs": "^1.1.0",
+        "stats-gl": "^1.0.4",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.6.7",
+        "three-stdlib": "^2.28.0",
+        "troika-three-text": "^0.47.2",
+        "utility-types": "^3.10.0",
+        "uuid": "^9.0.1",
+        "zustand": "^3.5.13"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8.0",
+        "react": ">=18.0",
+        "react-dom": ">=18.0",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/drei/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@react-three/fiber": {
@@ -4115,6 +4244,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.9.tgz",
+      "integrity": "sha512-4MMUjMQb4yA5fJ4osXx+QxGHt0/ZSy4spT6jL1HM7Tn8OJEC35siqdnpOo+HxPhYjqEFumKfGVF9hJfdyKBIBA=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.7",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.7.tgz",
@@ -4474,6 +4608,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -4593,6 +4732,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
+      "integrity": "sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==",
+      "peer": true
+    },
     "node_modules/@types/stylis": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.3.tgz",
@@ -4604,6 +4749,18 @@
       "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
       "dependencies": {
         "@types/jest": "*"
+      }
+    },
+    "node_modules/@types/three": {
+      "version": "0.158.3",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.158.3.tgz",
+      "integrity": "sha512-6Qs1rUvLSbkJ4hlIe6/rdwIf61j1x2UKvGJg7s8KjswYsz1C1qDTs6voVXXB8kYaI0hgklgZgbZUupfL1l9xdA==",
+      "peer": true,
+      "dependencies": {
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.6.10",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -4859,6 +5016,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.0.tgz",
+      "integrity": "sha512-rh+6MND31zfHcy9VU3dOZCqGY511lvGcfyJenN4cWZe0u1BH6brBpBddLVXhF2r4BMqWbvxfsbL7D287thJU2A=="
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.0.tgz",
+      "integrity": "sha512-3zc+Ve99z4usVP6l9knYVbVnZgfqhKah7sIG+PS2w+vpig2v2OLct05vs+ZXMzwxdNCMka8B+8WlOo0z6Pn6DA==",
+      "dependencies": {
+        "@use-gesture/core": "10.3.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -5813,6 +5986,14 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -6121,6 +6302,14 @@
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.7.3.tgz",
+      "integrity": "sha512-L4mxjBd3u8qiOLozdWrH2P8ZybSsDXBF7iyNyqNEFJhPUkovmuARWR8JTc1B/qlclOIg6FvZZA/0uAZMMim0mw==",
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-api": {
@@ -6518,6 +6707,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -7272,6 +7478,14 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.37",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.37.tgz",
+      "integrity": "sha512-EraWs84faI4iskB4qvE39bevMIazEvd1RpoyGLOBesRLbiz6eMeJqqRPHjEFClfRByYZzi9IzU35rBXIO76oDw==",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -7474,6 +7688,11 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.6.tgz",
+      "integrity": "sha512-+3NaRjWktb5r61ZFoDejlykPEFKT5N/LkbXsaddlw6xNSXBanUYpFc2AXXpbJDilPHazcSreU/DpQIaxfX0NfQ=="
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -8791,6 +9010,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9418,6 +9642,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -12829,6 +13058,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.clamp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
+      "integrity": "sha512-HvzRFWjtcguTW7yd8NJBshuNaCa8aqNFtnswdT7f/cMd/1YKy5Zzoq4W/Oxvnx9l7aeY258uSdDfM793+eLsVg=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -12843,6 +13077,16 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
+    },
+    "node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -12887,6 +13131,15 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.9.0.tgz",
+      "integrity": "sha512-aAR8hoUqPxlsU8VOxkS9y37jhUzdUxM017NpCuxFU1Gk+nMaZASZxymZrV8LRSHzRk/watlbfyNKu6XPUhCFrQ==",
+      "peerDependencies": {
+        "@types/three": ">=0.144.0",
+        "three": ">=0.144.0"
       }
     },
     "node_modules/magic-string": {
@@ -12977,6 +13230,20 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.1.7.tgz",
+      "integrity": "sha512-uf9fPI9wy0Ie0kZjvKuIkf2n7gi3ih0wdTeb/kmSvmzpPyEL5d9lFohg9+JV9VC4sQUBOZDgxu6fnjn57goSHg==",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "peer": true
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -15031,6 +15298,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15319,6 +15591,17 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -15457,6 +15740,15 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
     },
     "node_modules/react-query": {
       "version": "3.39.3",
@@ -16705,6 +16997,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/stats-gl": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-1.0.7.tgz",
+      "integrity": "sha512-vZI82CjefSxLC1bjw36z28v0+QE9rJKymGlXtfWu+ipW70ZEAwa4EbO4LxluAfLfpqiaAS04NzpYBRLDeAwYWQ=="
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw=="
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -17378,6 +17680,46 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.158.0.tgz",
       "integrity": "sha512-TALj4EOpdDPF1henk2Q+s17K61uEAAWQ7TJB68nr7FKxqwyDr3msOt5IWdbGm4TaWKjrtWS8DJJWe9JnvsWOhQ=="
     },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.6.8.tgz",
+      "integrity": "sha512-EGebF9DZx1S8+7OZYNNTT80GXJZVf+UYXD/HyTg/e2kR/ApofIFfUS4ZzIHNnUVIadpnLSzM4n96wX+l7GMbnQ==",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.28.7",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.28.7.tgz",
+      "integrity": "sha512-E7NuztilCswBKnEoyqydvA7N4dy0cf/gLA0bKrrg6+Q6j4WtusGa/+t9oK2HVq47S1AHRH2CvFHpdIGNjPKo/A==",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three.js": {
+      "version": "0.77.1",
+      "resolved": "https://registry.npmjs.org/three.js/-/three.js-0.77.1.tgz",
+      "integrity": "sha512-lVMYlBXhhHlZtsF+cQdev6WCm2fSWs3I+A6Z63j6TBmkVXOYgdo9AUCRemfsw5mllqWx23VubJ5Qt8/uWKQpJA==",
+      "dependencies": {
+        "three": "0.77.0"
+      }
+    },
+    "node_modules/three.js/node_modules/three": {
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.77.0.tgz",
+      "integrity": "sha512-YWEp8ahs2l+6fAFVbanLVQoSBwVq5jDct3nZdBSHHXb5I/w5oy/LCMAzIOAguKWclRqcjR4W1BeP5QBnftGbpA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/throat": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
@@ -17464,6 +17806,33 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.47.2.tgz",
+      "integrity": "sha512-qylT0F+U7xGs+/PEf3ujBdJMYWbn0Qci0kLqI5BJG2kW1wdg4T1XSxneypnF05DxFqJhEzuaOR9S2SjiyknMng==",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.47.2",
+        "troika-worker-utils": "^0.47.2",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.47.2.tgz",
+      "integrity": "sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.47.2",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.47.2.tgz",
+      "integrity": "sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA=="
     },
     "node_modules/tryer": {
       "version": "1.0.1",
@@ -17842,6 +18211,14 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA=="
     },
+    "node_modules/utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -17936,6 +18313,16 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/FE/package.json
+++ b/FE/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@react-three/drei": "^9.88.17",
     "@react-three/fiber": "^8.15.10",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
@@ -15,6 +16,7 @@
     "styled-components": "^6.1.1",
     "styled-reset": "^4.5.1",
     "three": "^0.158.0",
+    "three.js": "^0.77.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/FE/src/atoms/diaryAtom.js
+++ b/FE/src/atoms/diaryAtom.js
@@ -10,6 +10,8 @@ const diaryAtom = atom({
     isList: false,
     diaryUuid: "",
     diaryPoint: "",
+    diaryList: [],
+    refetch: () => {},
     isLoaded: false,
   },
 });

--- a/FE/src/atoms/diaryAtom.js
+++ b/FE/src/atoms/diaryAtom.js
@@ -9,6 +9,7 @@ const diaryAtom = atom({
     isDelete: false,
     isList: false,
     diaryUuid: "",
+    diaryPoint: "",
     isLoaded: false,
   },
 });

--- a/FE/src/atoms/diaryAtom.js
+++ b/FE/src/atoms/diaryAtom.js
@@ -11,7 +11,6 @@ const diaryAtom = atom({
     diaryUuid: "",
     diaryPoint: "",
     diaryList: [],
-    refetch: () => {},
     isLoaded: false,
   },
 });

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -10,13 +10,13 @@ import ModalWrapper from "../../styles/Modal/ModalWrapper";
 import DiaryModalHeader from "../../styles/Modal/DiaryModalHeader";
 import deleteIcon from "../../assets/deleteIcon.svg";
 
-function DiaryCreateModal() {
+function DiaryCreateModal(props) {
+  const { refetch } = props;
   const [isInput, setIsInput] = useState(false);
   const diaryState = useRecoilValue(diaryAtom);
   const userState = useRecoilValue(userAtom);
   const setDiaryState = useSetRecoilState(diaryAtom);
 
-<<<<<<< HEAD
   // TODO: 날짜 선택 기능 구현
   const [diaryData, setDiaryData] = React.useState({
     title: "",
@@ -27,7 +27,7 @@ function DiaryCreateModal() {
     shapeUuid: "",
   });
   const [newShapeData, setNewShapeData] = useState(null);
-=======
+
   useEffect(() => {
     const handleBeforeUnload = (e) => {
       e.preventDefault();
@@ -40,14 +40,6 @@ function DiaryCreateModal() {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
   }, []);
-
-  const closeModal = () => {
-    setDiaryState((prev) => ({
-      ...prev,
-      isCreate: false,
-    }));
-  };
->>>>>>> main
 
   const addTag = (e) => {
     if (e.target.value.length > 0 && !diaryData.tags.includes(e.target.value)) {
@@ -90,7 +82,7 @@ function DiaryCreateModal() {
     })
       .then((res) => res.json())
       .then(() => {
-        diaryState.refetch();
+        refetch();
         setDiaryState((prev) => ({
           ...prev,
           isLoading: true,

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -27,10 +27,6 @@ function DiaryCreateModal() {
   });
   const [newShapeData, setNewShapeData] = useState(null);
 
-  const closeModal = () => {
-    setDiaryState((prev) => ({ ...prev, isCreate: false }));
-  };
-
   const addTag = (e) => {
     if (e.target.value.length > 0 && !diaryData.tags.includes(e.target.value)) {
       setDiaryData({
@@ -71,21 +67,12 @@ function DiaryCreateModal() {
       body: JSON.stringify(data.diaryData),
     })
       .then((res) => res.json())
-      .then((res) => {
+      .then(() => {
         diaryState.refetch();
         setDiaryState((prev) => ({
           ...prev,
           isLoading: true,
         }));
-        setTimeout(() => {
-          setDiaryState((prev) => ({
-            ...prev,
-            isCreate: false,
-            isRead: true,
-            isLoading: false,
-            diaryUuid: res.uuid,
-          }));
-        }, 3000);
       });
   }
 
@@ -201,7 +188,11 @@ function DiaryCreateModal() {
         setDiaryData={setDiaryData}
       />
       <ModalSideButtonWrapper>
-        <ModalSideButton onClick={closeModal}>
+        <ModalSideButton
+          onClick={() => {
+            setDiaryState((prev) => ({ ...prev, isCreate: false }));
+          }}
+        >
           <img src={deleteIcon} alt='delete' />
         </ModalSideButton>
         {isInput ? (
@@ -209,7 +200,7 @@ function DiaryCreateModal() {
             width='5rem'
             onClick={() => {
               createDiary({ diaryData, accessToken: userState.accessToken });
-              closeModal();
+              setDiaryState((prev) => ({ ...prev, isCreate: false }));
             }}
           >
             생성

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -146,7 +146,7 @@ function DiaryCreateModal() {
   } = useMutation(createDiaryFn);
 
   return (
-    <ModalWrapper left='60%' width='40vw' height='65vh' opacity='0.3'>
+    <ModalWrapper left='50%' width='40vw' height='65vh' opacity='0.3'>
       <DiaryModalHeader>
         <DiaryModalTitle>새로운 별의 이야기를 적어주세요.</DiaryModalTitle>
         <DiaryModalDate>{diaryData.date}</DiaryModalDate>

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -10,19 +10,20 @@ import ModalWrapper from "../../styles/Modal/ModalWrapper";
 import DiaryModalHeader from "../../styles/Modal/DiaryModalHeader";
 import deleteIcon from "../../assets/deleteIcon.svg";
 
-// TODO: 일기 데이터 수정 API 연결
 function DiaryCreateModal() {
   const [isInput, setIsInput] = useState(false);
   const diaryState = useRecoilValue(diaryAtom);
   const userState = useRecoilValue(userAtom);
   const setDiaryState = useSetRecoilState(diaryAtom);
+
+  // TODO: 날짜 선택 기능 구현
   const [diaryData, setDiaryData] = React.useState({
-    title: "test",
-    content: "test",
-    date: "2023-11-20",
+    title: "",
+    content: "",
+    date: "2023-11-19",
     point: diaryState.diaryPoint,
     tags: [],
-    shapeUuid: "cf3a074a-0707-40c4-a598-c7c17a654476",
+    shapeUuid: "",
   });
   const [newShapeData, setNewShapeData] = useState(null);
 
@@ -71,6 +72,7 @@ function DiaryCreateModal() {
     })
       .then((res) => res.json())
       .then((res) => {
+        diaryState.refetch();
         setDiaryState((prev) => ({
           ...prev,
           isLoading: true,
@@ -147,13 +149,7 @@ function DiaryCreateModal() {
     <ModalWrapper left='60%' width='40vw' height='65vh' opacity='0.3'>
       <DiaryModalHeader>
         <DiaryModalTitle>새로운 별의 이야기를 적어주세요.</DiaryModalTitle>
-        <DiaryModalDate>
-          {new Date().toLocaleDateString("ko-KR", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-          })}
-        </DiaryModalDate>
+        <DiaryModalDate>{diaryData.date}</DiaryModalDate>
       </DiaryModalHeader>
       <DiaryModalInputBox
         fontSize='1.1rem'

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -13,17 +13,18 @@ import deleteIcon from "../../assets/deleteIcon.svg";
 // TODO: 일기 데이터 수정 API 연결
 function DiaryCreateModal() {
   const [isInput, setIsInput] = useState(false);
-  const [diaryData, setDiaryData] = useState({
+  const diaryState = useRecoilValue(diaryAtom);
+  const userState = useRecoilValue(userAtom);
+  const setDiaryState = useSetRecoilState(diaryAtom);
+  const [diaryData, setDiaryData] = React.useState({
     title: "test",
     content: "test",
     date: "2023-11-20",
-    point: "0,0,0",
+    point: diaryState.diaryPoint,
     tags: [],
     shapeUuid: "cf3a074a-0707-40c4-a598-c7c17a654476",
   });
   const [newShapeData, setNewShapeData] = useState(null);
-  const userState = useRecoilValue(userAtom);
-  const setDiaryState = useSetRecoilState(diaryAtom);
 
   const closeModal = () => {
     setDiaryState((prev) => ({ ...prev, isCreate: false }));

--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -6,20 +6,23 @@ import diaryAtom from "../../atoms/diaryAtom";
 import userAtom from "../../atoms/userAtom";
 import ModalWrapper from "../../styles/Modal/ModalWrapper";
 
-async function deleteDiaryFn(data) {
-  return fetch(`http://223.130.129.145:3005/diaries/${data.diaryUuid}`, {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${data.accessToken}`,
-    },
-  });
-}
-
 function DiaryDeleteModal() {
   const diaryState = useRecoilValue(diaryAtom);
   const userState = useRecoilValue(userAtom);
   const setDiaryState = useSetRecoilState(diaryAtom);
+
+  async function deleteDiaryFn(data) {
+    return fetch(`http://223.130.129.145:3005/diaries/${data.diaryUuid}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${data.accessToken}`,
+      },
+    }).then(() => {
+      diaryState.refetch();
+    });
+  }
+
   const {
     mutate: deleteDiary,
     // isLoading,

--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -20,6 +20,10 @@ function DiaryDeleteModal() {
       },
     }).then(() => {
       diaryState.refetch();
+      setDiaryState((prev) => ({
+        ...prev,
+        isLoading: true,
+      }));
     });
   }
 

--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -6,7 +6,8 @@ import diaryAtom from "../../atoms/diaryAtom";
 import userAtom from "../../atoms/userAtom";
 import ModalWrapper from "../../styles/Modal/ModalWrapper";
 
-function DiaryDeleteModal() {
+function DiaryDeleteModal(props) {
+  const { refetch } = props;
   const diaryState = useRecoilValue(diaryAtom);
   const userState = useRecoilValue(userAtom);
   const setDiaryState = useSetRecoilState(diaryAtom);
@@ -19,11 +20,7 @@ function DiaryDeleteModal() {
         Authorization: `Bearer ${data.accessToken}`,
       },
     }).then(() => {
-      diaryState.refetch();
-      setDiaryState((prev) => ({
-        ...prev,
-        isLoading: true,
-      }));
+      refetch();
     });
   }
 

--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -1,35 +1,18 @@
 import React, { useEffect, useLayoutEffect } from "react";
-import { useQuery } from "react-query";
 import styled from "styled-components";
-import { useRecoilValue, useSetRecoilState } from "recoil";
-import userAtom from "../../atoms/userAtom";
+import { useRecoilState } from "recoil";
 import diaryAtom from "../../atoms/diaryAtom";
 import zoomIn from "../../assets/zoomIn.svg";
 
 function DiaryListModal() {
   const [selectedDiary, setSelectedDiary] = React.useState(null);
-  const userState = useRecoilValue(userAtom);
-  const setDiaryState = useSetRecoilState(diaryAtom);
-
-  const {
-    data: DiaryList,
-    isError,
-    isLoading,
-  } = useQuery("diaryList", () =>
-    fetch("http://223.130.129.145:3005/diaries", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${userState.accessToken}`,
-      },
-    }).then((res) => res.json()),
-  );
+  const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
 
   useLayoutEffect(() => {
-    if (DiaryList) {
-      setSelectedDiary(DiaryList[0]);
+    if (diaryState.diaryList) {
+      setSelectedDiary(diaryState.diaryList[0]);
     }
-  }, [DiaryList]);
+  }, [diaryState.diaryList]);
 
   useEffect(() => {
     if (selectedDiary) {
@@ -39,26 +22,6 @@ function DiaryListModal() {
       }));
     }
   }, [selectedDiary]);
-
-  if (isLoading)
-    return (
-      <DiaryListModalWrapper>
-        <DiaryListModalItem />
-        <DiaryListModalItem />
-        <DiaryListModalItem width='50%' />
-      </DiaryListModalWrapper>
-    );
-
-  if (isError)
-    return (
-      <DiaryListModalWrapper>
-        <DiaryListModalItem />
-        <DiaryListModalItem />
-        <DiaryListModalItem width='50%'>
-          일기 목록을 불러오는데 실패했습니다.
-        </DiaryListModalItem>
-      </DiaryListModalWrapper>
-    );
 
   return (
     <DiaryListModalWrapper>
@@ -87,7 +50,7 @@ function DiaryListModal() {
             e.target.focus();
           }}
         >
-          {DiaryList?.map((diary) => (
+          {diaryState.diaryList?.map((diary) => (
             <DiaryTitleListItem
               key={diary.uuid}
               onClick={() => {

--- a/FE/src/components/DiaryModal/DiaryLoadingModal.js
+++ b/FE/src/components/DiaryModal/DiaryLoadingModal.js
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useLayoutEffect } from "react";
 import styled from "styled-components";
+import { useSetRecoilState } from "recoil";
+import diaryAtom from "../../atoms/diaryAtom";
 import ModalWrapper from "../../styles/Modal/ModalWrapper";
 import {
   LoadingAnimationWrapper,
@@ -7,17 +9,35 @@ import {
 } from "../../styles/Modal/LoadingAnimation";
 
 function DiaryLoadingModal() {
+  const setDiaryState = useSetRecoilState(diaryAtom);
+
+  useLayoutEffect(() => {
+    setDiaryState((prev) => ({
+      ...prev,
+      isCreate: false,
+      isRead: false,
+      isUpdate: false,
+      isDelete: false,
+    }));
+    setTimeout(() => {
+      setDiaryState((prev) => ({
+        ...prev,
+        isLoading: false,
+      }));
+    }, 1000);
+  }, []);
+
   return (
     <>
       <DiaryLoadingModalWrapper>
         <LoadingAnimationWrapper>
           <LoadingAnimationIcon />
         </LoadingAnimationWrapper>
-        <DiaryLoadingTitle>일기 저장 중</DiaryLoadingTitle>
+        <DiaryLoadingTitle>로딩 중입니다.</DiaryLoadingTitle>
         <DiaryLoadingContent>
-          감정 분석 결과와 함께
+          당신의 새로운 별자리를
           <br />
-          보여드릴게요.
+          보여드릴게요
         </DiaryLoadingContent>
       </DiaryLoadingModalWrapper>
       <DiaryLoadingModalBackground />

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -116,7 +116,7 @@ function DiaryReadModal() {
     );
 
   return (
-    <ModalWrapper left='67%' width='40vw' height='65vh' opacity='0.3'>
+    <ModalWrapper left='50%' width='40vw' height='65vh' opacity='0.3'>
       <DiaryModalHeader>
         <DiaryModalTitle>{data.title}</DiaryModalTitle>
         <DiaryButton

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -53,7 +53,8 @@ async function getDiary(accessToken, diaryUuid) {
   }).then((res) => res.json());
 }
 
-function DiaryReadModal() {
+function DiaryReadModal(props) {
+  const { refetch } = props;
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
   const userState = useRecoilValue(userAtom);
   const [shapeData, setShapeData] = React.useState("");
@@ -194,7 +195,7 @@ function DiaryReadModal() {
           />
         </DiaryModalIcon>
       </DiaryModalEmotionBar>
-      {diaryState.isDelete ? <DiaryDeleteModal /> : null}
+      {diaryState.isDelete ? <DiaryDeleteModal refetch={refetch} /> : null}
     </ModalWrapper>
   );
 }

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { useMutation, useQuery } from "react-query";
 import styled from "styled-components";
 import userAtom from "../../atoms/userAtom";
@@ -28,12 +28,13 @@ async function getDiary(accessToken, diaryUuid) {
 }
 
 // TODO: 일기 데이터 수정 API 연결
-function DiaryUpdateModal() {
+function DiaryUpdateModal(props) {
+  const { refetch } = props;
   const titleRef = useRef(null);
   const contentRef = useRef(null);
   const [isInput, setIsInput] = React.useState(true);
   const userState = useRecoilValue(userAtom);
-  const diaryState = useRecoilValue(diaryAtom);
+  const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
   const [diaryData, setDiaryData] = React.useState({
     title: "test",
     content: "test",
@@ -53,7 +54,7 @@ function DiaryUpdateModal() {
       },
       body: JSON.stringify(data.diaryData),
     }).then(() => {
-      diaryState.refetch();
+      refetch();
       setDiaryState((prev) => ({
         ...prev,
         isLoading: true,

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -54,6 +54,10 @@ function DiaryUpdateModal() {
       body: JSON.stringify(data.diaryData),
     }).then(() => {
       diaryState.refetch();
+      setDiaryState((prev) => ({
+        ...prev,
+        isLoading: true,
+      }));
     });
   }
 

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -17,17 +17,6 @@ async function getShapeFn() {
   }).then((res) => res.json());
 }
 
-async function updateDiaryFn(data) {
-  return fetch("http://223.130.129.145:3005/diaries", {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${data.accessToken}`,
-    },
-    body: JSON.stringify(data.diaryData),
-  });
-}
-
 async function getDiary(accessToken, diaryUuid) {
   return fetch(`http://223.130.129.145:3005/diaries/${diaryUuid}`, {
     method: "GET",
@@ -54,6 +43,19 @@ function DiaryUpdateModal() {
     shapeUuid: "cf3a074a-0707-40c4-a598-c7c17a654476",
     uuid: diaryState.diaryUuid,
   });
+
+  async function updateDiaryFn(data) {
+    return fetch("http://223.130.129.145:3005/diaries", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${data.accessToken}`,
+      },
+      body: JSON.stringify(data.diaryData),
+    }).then(() => {
+      diaryState.refetch();
+    });
+  }
 
   const closeModal = () => {
     setDiaryState((prev) => ({ ...prev, isUpdate: false }));

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -118,20 +118,20 @@ function DiaryUpdateModal() {
 
   if (isLoading)
     return (
-      <ModalWrapper left='60%' width='40vw' height='65vh' opacity='0.3'>
+      <ModalWrapper left='50%' width='40vw' height='65vh' opacity='0.3'>
         Loading...
       </ModalWrapper>
     );
 
   if (isError)
     return (
-      <ModalWrapper left='60%' width='40vw' height='65vh' opacity='0.3'>
+      <ModalWrapper left='50%' width='40vw' height='65vh' opacity='0.3'>
         에러 발생
       </ModalWrapper>
     );
 
   return (
-    <ModalWrapper left='60%' width='40vw' height='65vh' opacity='0.3'>
+    <ModalWrapper left='50%' width='40vw' height='65vh' opacity='0.3'>
       <DiaryModalHeader>
         <DiaryModalTitle>바뀐 별의 이야기를 적어주세요.</DiaryModalTitle>
         <DiaryModalDate>

--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -49,7 +49,7 @@ function DiaryUpdateModal() {
     title: "test",
     content: "test",
     date: "2023-11-20",
-    point: "0,0,0",
+    point: diaryState.diaryPoint,
     tags: [],
     shapeUuid: "cf3a074a-0707-40c4-a598-c7c17a654476",
     uuid: diaryState.diaryUuid,
@@ -105,6 +105,7 @@ function DiaryUpdateModal() {
           ...diaryData,
           title: data.title,
           content: data.content,
+          date: data.date,
           tags: data.tags,
         });
         titleRef.current.value = data.title;

--- a/FE/src/components/SideBar/SideBar.js
+++ b/FE/src/components/SideBar/SideBar.js
@@ -36,12 +36,13 @@ function SideBar() {
                 ...prev,
                 isSideBar: false,
               }));
-              setDiaryState({
+              setDiaryState((prev) => ({
+                ...prev,
                 isCreate: false,
                 isRead: false,
                 isDelete: false,
                 isList: true,
-              });
+              }));
             }}
           >
             일기 목록

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -4,10 +4,10 @@ import { useRecoilState } from "recoil";
 import diaryAtom from "../atoms/diaryAtom";
 import DiaryCreateModal from "../components/DiaryModal/DiaryCreateModal";
 import DiaryReadModal from "../components/DiaryModal/DiaryReadModal";
-import background from "../assets/background.png";
 import DiaryListModal from "../components/DiaryModal/DiaryListModal";
 import DiaryUpdateModal from "../components/DiaryModal/DiaryUpdateModal";
 import DiaryLoadingModal from "../components/DiaryModal/DiaryLoadingModal";
+import StarPage from "./StarPage";
 
 function MainPage() {
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
@@ -20,6 +20,7 @@ function MainPage() {
           setDiaryState((prev) => ({ ...prev, isCreate: true, isRead: false }));
         }}
       />
+      <StarPage />
       {diaryState.isCreate ? <DiaryCreateModal /> : null}
       {diaryState.isRead ? <DiaryReadModal /> : null}
       {diaryState.isUpdate ? <DiaryUpdateModal /> : null}
@@ -32,10 +33,6 @@ function MainPage() {
 // TODO: 배경 이미지 제거하고 영상으로 대체할 것
 const MainPageWrapper = styled.div`
   height: 100vh;
-  background-image: url(${background});
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: cover;
 
   display: flex;
   justify-content: center;

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -33,8 +33,8 @@ function MainPage() {
   );
 
   useEffect(() => {
-    refetch();
-  }, [diaryState]);
+    setDiaryState((prev) => ({ ...prev, refetch }));
+  }, [refetch]);
 
   return (
     <>

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -33,10 +33,6 @@ function MainPage() {
   );
 
   useEffect(() => {
-    setDiaryState((prev) => ({ ...prev, refetch }));
-  }, [refetch]);
-
-  useEffect(() => {
     setDiaryState((prev) => {
       const newState = {
         ...prev,
@@ -65,9 +61,9 @@ function MainPage() {
         }}
       />
       <StarPage />
-      {diaryState.isCreate ? <DiaryCreateModal /> : null}
-      {diaryState.isRead ? <DiaryReadModal /> : null}
-      {diaryState.isUpdate ? <DiaryUpdateModal /> : null}
+      {diaryState.isCreate ? <DiaryCreateModal refetch={refetch} /> : null}
+      {diaryState.isRead ? <DiaryReadModal refetch={refetch} /> : null}
+      {diaryState.isUpdate ? <DiaryUpdateModal refetch={refetch} /> : null}
       {diaryState.isList ? <DiaryListModal /> : null}
       {diaryState.isLoading ? <DiaryLoadingModal /> : null}
     </>

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useQuery } from "react-query";
 import styled from "styled-components";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import diaryAtom from "../atoms/diaryAtom";
+import userAtom from "../atoms/userAtom";
 import DiaryCreateModal from "../components/DiaryModal/DiaryCreateModal";
 import DiaryReadModal from "../components/DiaryModal/DiaryReadModal";
 import DiaryListModal from "../components/DiaryModal/DiaryListModal";
@@ -11,6 +13,28 @@ import StarPage from "./StarPage";
 
 function MainPage() {
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
+  const userState = useRecoilValue(userAtom);
+
+  const { refetch } = useQuery(
+    "diaryList",
+    () =>
+      fetch("http://223.130.129.145:3005/diaries", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${userState.accessToken}`,
+        },
+      }).then((res) => res.json()),
+    {
+      onSuccess: (data) => {
+        setDiaryState((prev) => ({ ...prev, diaryList: data }));
+      },
+    },
+  );
+
+  useEffect(() => {
+    refetch();
+  }, [diaryState]);
 
   return (
     <>

--- a/FE/src/pages/StarPage.js
+++ b/FE/src/pages/StarPage.js
@@ -16,6 +16,7 @@ function StarPage() {
           position: [-1, -1, -1],
         }}
       >
+        <ambientLight />
         <OrbitControls
           enablePan={false}
           enableDamping={false}
@@ -31,6 +32,35 @@ function StarPage() {
 function StarView() {
   const { scene, raycaster, camera } = useThree();
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
+
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      color1: { value: new THREE.Color("#656990") },
+      color2: { value: new THREE.Color("#182683") },
+      gradientStart: { value: 0.001 },
+    },
+    vertexShader: `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      uniform vec3 color1;
+      uniform vec3 color2;
+      uniform float gradientStart;
+      varying vec2 vUv;
+      void main() {
+        vec3 finalColor = mix(
+          color1,
+          color2,
+          smoothstep(gradientStart, gradientStart + 0.15, vUv.y)
+        );
+        gl_FragColor = vec4(finalColor, 1.0);
+      }
+    `,
+  });
 
   const moveToStar = async (e, fn) => {
     raycaster.set(new THREE.Vector3(0, 0, 0), e.point);
@@ -86,11 +116,7 @@ function StarView() {
         }}
       >
         <sphereGeometry args={[30, 32, 16, 0, Math.PI * 2, 0, Math.PI / 2]} />
-        <meshStandardMaterial
-          emissive={0x13275a}
-          emissiveIntensity={0.8}
-          side={THREE.BackSide}
-        />
+        <primitive object={material} attach='material' side={THREE.BackSide} />
       </mesh>
       <mesh>
         <sphereGeometry args={[3]} />
@@ -157,7 +183,7 @@ function Star(props) {
 const CanvasContainer = styled.div`
   width: 100%;
   height: 100%;
-  background-color: #000000ee;
+  background-color: #000000;
 
   position: absolute;
   top: 0;

--- a/FE/src/pages/StarPage.js
+++ b/FE/src/pages/StarPage.js
@@ -1,0 +1,183 @@
+/* eslint-disable react/no-unknown-property */
+
+import React, { useEffect } from "react";
+import { useQuery } from "react-query";
+import { useRecoilState, useSetRecoilState, useRecoilValue } from "recoil";
+import styled from "styled-components";
+import { Canvas, useThree } from "@react-three/fiber";
+import { Sphere, OrbitControls } from "@react-three/drei";
+import * as THREE from "three";
+import diaryAtom from "../atoms/diaryAtom";
+import userAtom from "../atoms/userAtom";
+
+function StarPage() {
+  return (
+    <CanvasContainer>
+      <Canvas
+        camera={{
+          position: [-1, -1, -1],
+        }}
+      >
+        <OrbitControls
+          enablePan={false}
+          enableDamping={false}
+          enableZoom={false}
+          target={[0, 0, 0]}
+        />
+        <StarView />
+      </Canvas>
+    </CanvasContainer>
+  );
+}
+
+function StarView() {
+  const { scene, raycaster, camera } = useThree();
+  const [DiaryState, setDiaryState] = useRecoilState(diaryAtom);
+  const userState = useRecoilValue(userAtom);
+
+  const {
+    data: DiaryList,
+    isLoading,
+    refetch,
+  } = useQuery("diaryList", () =>
+    fetch("http://223.130.129.145:3005/diaries", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userState.accessToken}`,
+      },
+    }).then((res) => res.json()),
+  );
+
+  const moveToStar = async (e, fn) => {
+    raycaster.set(new THREE.Vector3(0, 0, 0), e.point);
+    const intersects = raycaster.intersectObjects(scene.children);
+
+    if (intersects.length > 0) {
+      const [ntx, nty, ntz] = intersects[0].point.toArray().map((v) => -v);
+      const targetPosition = new THREE.Vector3(ntx, nty, ntz);
+
+      const animate = () => {
+        const currentPosition = camera.position.clone();
+        const direction = targetPosition.clone().sub(currentPosition);
+        const distance = direction.length();
+
+        if (distance > 0.05) {
+          const moveDistance = Math.min(0.05, distance);
+          direction.normalize().multiplyScalar(moveDistance);
+          camera.position.add(direction);
+          requestAnimationFrame(animate);
+        } else {
+          fn(e.point.toArray());
+        }
+      };
+
+      animate();
+    }
+  };
+
+  useEffect(() => {
+    refetch();
+  }, [DiaryState]);
+
+  if (isLoading) return null;
+
+  return (
+    <>
+      <mesh
+        onClick={() => {
+          setDiaryState((prev) => ({
+            ...prev,
+            isRead: false,
+          }));
+        }}
+        onDoubleClick={(e) => {
+          moveToStar(e, () => {
+            setDiaryState((prev) => ({
+              ...prev,
+              isCreate: true,
+              isRead: false,
+              diaryPoint: `${e.point.x},${e.point.y},${e.point.z}`,
+            }));
+          });
+        }}
+      >
+        <sphereGeometry args={[30, 32, 16, 0, Math.PI * 2, 0, Math.PI / 2]} />
+        <meshStandardMaterial
+          emissive={0x13275a}
+          emissiveIntensity={0.8}
+          side={THREE.BackSide}
+        />
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[3]} />
+        <meshStandardMaterial transparent opacity={0} side={THREE.BackSide} />
+      </mesh>
+      {DiaryList.map((diary) => (
+        <Star
+          key={[diary.coordinate.x, diary.coordinate.y, diary.coordinate.z]}
+          uuid={diary.uuid}
+          position={[
+            diary.coordinate.x,
+            diary.coordinate.y,
+            diary.coordinate.z,
+          ]}
+          moveToStar={moveToStar}
+        />
+      ))}
+    </>
+  );
+}
+
+function Star(props) {
+  const { uuid, position, moveToStar } = props;
+  const setDiaryState = useSetRecoilState(diaryAtom);
+
+  return (
+    <mesh
+      position={position}
+      onPointerEnter={(e) => {
+        e.stopPropagation();
+        e.object.scale.set(1.5, 1.5, 1.5);
+        e.object.material.emissiveIntensity = 1;
+      }}
+      onPointerLeave={(e) => {
+        e.stopPropagation();
+        e.object.scale.set(1, 1, 1);
+        e.object.material.emissiveIntensity = 0.7;
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        setDiaryState((prev) => ({
+          ...prev,
+          isCreate: false,
+          isRead: false,
+          diaryUuid: uuid,
+        }));
+        moveToStar(e, () => {
+          setDiaryState((prev) => ({
+            ...prev,
+            isCreate: false,
+            isRead: true,
+          }));
+        });
+      }}
+    >
+      <Sphere args={[0.2]}>
+        <meshStandardMaterial emissive={0xffffff} emissiveIntensity={0.7} />
+      </Sphere>
+    </mesh>
+  );
+}
+
+const CanvasContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: #000000ee;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+export default StarPage;

--- a/FE/src/pages/StarPage.js
+++ b/FE/src/pages/StarPage.js
@@ -136,6 +136,7 @@ function Star(props) {
           isCreate: false,
           isRead: false,
           diaryUuid: uuid,
+          diaryPoint: `${e.point.x},${e.point.y},${e.point.z}`,
         }));
         moveToStar(e, () => {
           setDiaryState((prev) => ({


### PR DESCRIPTION
## 요약

- 메인 페이지 3D 뷰 구현
- 빈 공간 더블 클릭을 통한 시점 이동
- 빈 공간 더블 클릭을 통한 일기 생성 API 연동
- 별 클릭을 통한 시점 이동
- 별 클릭을 통한 일기 조회 API 연동

https://github.com/boostcampwm2023/web08-ByeolSoop/assets/67178684/96be93d2-5f49-4c1e-b67d-87f1bd70f109

## 변경 사항

- 메인 페이지3D 뷰 구현
  - 원점 (0, 0, 0)을 기준으로 하는 OrbitControls
  - 카메라는 원점을 기준으로 반지름이 3인 구 위에서만 이동
  - 시점 이동 시 raycasting과requestAnimationFrame을 활용
  - 기존의 이미지 배경화면 대신 3D 뷰 적용
- API 연동을 위해 recoil, react-query 활용
  - 일기 데이터가 최신화될 때마다 컴포넌트들에 반영하기 위해 상위 컴포넌트에서 useQuery 관리
  - 모달의 상태 변화가 일어날 때마다 useQuery의 refetch를 활용하여 데이터 최신화

## 참고 사항

- 추후 디자인을 많이 바꿔야 될 것 같다.
- 시점 이동 애니메이션에 대해 연구해야 한다.

## 이슈 번호

close #158 
