### PR TITLE
[Perf] 모양 파일을 png에서 svg로 변경

### DIFF
--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Controller,
-  Get,
-  Header,
-  InternalServerErrorException,
-  Param,
-  StreamableFile,
-  UseGuards,
-} from "@nestjs/common";
+import { Controller, Get, Header, Param, UseGuards } from "@nestjs/common";
 import { ShapesService } from "./shapes.service";
 import { Shape } from "./shapes.entity";
 import { GetUser } from "src/auth/get-user.decorator";
@@ -24,18 +16,12 @@ export class ShapesController {
 
   @Get("/:uuid")
   @UseGuards(JwtAuthGuard)
-  @Header("Content-Type", "image/png")
+  @Header("Content-Type", "image/svg+xml")
   async getShapeFilesByUuid(
     @Param("uuid") uuid: string,
     @GetUser() user: User,
-  ): Promise<StreamableFile> {
-    const stream = await this.shapesService.getShapeFileByUuid(uuid, user);
-    try {
-      return new StreamableFile(stream);
-    } catch (error) {
-      throw new InternalServerErrorException(
-        "파일을 읽어오는 도중 서버에서 문제가 발생했습니다.",
-      );
-    }
+  ): Promise<string> {
+    const svgString = await this.shapesService.getShapeFileByUuid(uuid, user);
+    return svgString;
   }
 }

--- a/BE/src/shapes/shapes.controller.ts
+++ b/BE/src/shapes/shapes.controller.ts
@@ -21,7 +21,6 @@ export class ShapesController {
     @Param("uuid") uuid: string,
     @GetUser() user: User,
   ): Promise<string> {
-    const svgString = await this.shapesService.getShapeFileByUuid(uuid, user);
-    return svgString;
+    return this.shapesService.getShapeFileByUuid(uuid, user);
   }
 }

--- a/BE/src/shapes/shapes.default.ts
+++ b/BE/src/shapes/shapes.default.ts
@@ -1,7 +1,19 @@
 import { Shape } from "./shapes.entity";
 
 export const defaultShapes: Partial<Shape>[] = [
-  { shapePath: "test-basic-shape-1.png" },
-  { shapePath: "test-basic-shape-2.png" },
-  { shapePath: "test-basic-shape-3.png" },
+  { shapePath: "BasicShape1.svg" },
+  { shapePath: "BasicShape2.svg" },
+  { shapePath: "BasicShape3.svg" },
+  { shapePath: "BasicShape4.svg" },
+  { shapePath: "BasicShape5.svg" },
+  { shapePath: "BasicShape6.svg" },
+  { shapePath: "BasicShape7.svg" },
+  { shapePath: "BasicShape8.svg" },
+  { shapePath: "BasicShape9.svg" },
+  { shapePath: "BasicShape10.svg" },
+  { shapePath: "BasicShape11.svg" },
+  { shapePath: "BasicShape12.svg" },
+  { shapePath: "BasicShape13.svg" },
+  { shapePath: "BasicShape14.svg" },
+  { shapePath: "BasicShape15.svg" },
 ];

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -1,10 +1,9 @@
 import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ShapesRepository } from "./shapes.repository";
-import { getFileFromS3 } from "src/utils/e3";
+import { getShapeFromS3 } from "src/utils/e3";
 import { defaultShapes } from "./shapes.default";
 import { Shape } from "./shapes.entity";
 import { User } from "src/auth/users.entity";
-import { Readable } from "stream";
 
 @Injectable()
 export class ShapesService {
@@ -19,13 +18,15 @@ export class ShapesService {
     return shapeFiles;
   }
 
-  async getShapeFileByUuid(uuid: string, user: User): Promise<Readable> {
+  async getShapeFileByUuid(uuid: string, user: User): Promise<string> {
     const shape = await this.shapesRepository.getShapeByUuid(uuid);
     const { userId, id } = await shape.user;
 
     if (userId !== "commonUser" && id !== user.id) {
       throw new UnauthorizedException();
     }
-    return getFileFromS3(shape.shapePath);
+
+    const shapeFile = await getShapeFromS3(shape.shapePath);
+    return shapeFile;
   }
 }

--- a/BE/src/shapes/shapes.service.ts
+++ b/BE/src/shapes/shapes.service.ts
@@ -20,13 +20,12 @@ export class ShapesService {
 
   async getShapeFileByUuid(uuid: string, user: User): Promise<string> {
     const shape = await this.shapesRepository.getShapeByUuid(uuid);
-    const { userId, id } = await shape.user;
+    const { userId, id } = shape.user;
 
     if (userId !== "commonUser" && id !== user.id) {
       throw new UnauthorizedException();
     }
 
-    const shapeFile = await getShapeFromS3(shape.shapePath);
-    return shapeFile;
+    return getShapeFromS3(shape.shapePath);
   }
 }

--- a/BE/src/utils/e3.ts
+++ b/BE/src/utils/e3.ts
@@ -27,6 +27,31 @@ export function getFileFromS3(filePath: string): Readable {
   return readStream;
 }
 
+export async function getShapeFromS3(filePath: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const readStream = s3
+      .getObject({
+        Bucket: "byeolsoop-bucket",
+        Key: filePath,
+      })
+      .createReadStream();
+
+    let data = "";
+
+    readStream.on("data", (chunk) => {
+      data += chunk;
+    });
+
+    readStream.on("end", () => {
+      resolve(data);
+    });
+
+    readStream.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
 // export async function uploadFileToS3(): Promise<void> {
 //   await s3
 //     .putObject({


### PR DESCRIPTION
## 요약

- ncloud object storage에 업로드한 모양 이미지를 svg 파일로 교체
- 저장한 svg 파일을 기반으로, 기본 모양 15개를 commonUser에 등록
- 클라이언트가 모양 요청 시 svg string을 응답하도록 수정

## 변경 사항
### 저장한 svg 파일을 기반으로, 기본 모양 15개를 commonUser에 등록
- 새로 업로드한 모양 파일을 shapes.default에 등록함. 따라서 createDefaultShapes를 할 때 새로 업로드한 모양 파일이 업로드되도록 함.
- 
### 클라이언트가 모양 요청 시 svg string을 응답하도록 수정
- getShapeFromS3 함수를 새로 구현함. 오브젝트 스토리지에서 ReadableStream을 받아서 읽은 후 SVG String을 응답하도록 함
- Service의 getShapeFileByUuid 함수에서 getFileFromS3가 아니라 getShapeFromS3를 통해 요청된 이미지의 SVG String을 받아서 리턴함
- Controller의 getShapeFilesByUuid에서 Service에서 리턴받은 SVG String을 담아 응답하도록 수정 

## 참고 사항

-  ncloud object storage에 업로드한 모양 이미지를 svg 파일로 교체했습니다. 기존에는 임시로 3개의 이미지를 올려두었고, 현재는 전체 15개의 파일을 업로드한 상태입니다.

## 이슈 번호

close #163 
