### PR TITLE
[Fix] png -> svg로 변환된 데이터 이용 아이콘 구현

### DIFF
--- a/FE/.eslintrc.js
+++ b/FE/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
     "prettier/prettier": ["error", { endOfLine: "auto" }],
     "react/jsx-filename-extension": [1, { extensions: [".js", ".jsx"] }],
     "react/prop-types": "off",
+    "import/no-extraneous-dependencies": ["off"],
   },
 };

--- a/FE/.eslintrc.js
+++ b/FE/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
     "react/jsx-filename-extension": [1, { extensions: [".js", ".jsx"] }],
     "react/prop-types": "off",
     "import/no-extraneous-dependencies": ["off"],
+    "react/no-danger": "off",
   },
 };

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fe",
       "version": "0.1.0",
       "dependencies": {
-        "@react-three/drei": "^9.88.17",
+        "@react-three/drei": "^9.89.0",
         "@react-three/fiber": "^8.15.10",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -3423,9 +3423,9 @@
       "integrity": "sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q=="
     },
     "node_modules/@react-three/drei": {
-      "version": "9.88.17",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.88.17.tgz",
-      "integrity": "sha512-WEYAkikzw0juG3F1aMy1AEeuRmsGmKytb8ETZARd4E6Q61Z1ceoL7fRvrnrXE/A2MHKgSzJgkckMEhKlbbJlyw==",
+      "version": "9.89.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.89.0.tgz",
+      "integrity": "sha512-iddG7OAfng3a99nAO7erzb1wlwaY1Zlaz9EVfnW9ZiLm4rM322vXHnLX1zhrH5/AeRB/1t4bEu8uAHvXX3XwWA==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@mediapipe/tasks-vision": "0.10.8",

--- a/FE/package.json
+++ b/FE/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@react-three/drei": "^9.88.17",
+    "@react-three/drei": "^9.89.0",
     "@react-three/fiber": "^8.15.10",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -16,6 +16,7 @@ const GlobalStyle = createGlobalStyle`
 
   body {
     font-family: "Pretendard-Medium";
+	background-color: #000000;
   }
 
   * {

--- a/FE/src/atoms/shapeAtom.js
+++ b/FE/src/atoms/shapeAtom.js
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+const shapeAtom = atom({
+  key: "shapeState",
+  default: {},
+});
+
+export default shapeAtom;

--- a/FE/src/atoms/shapeAtom.js
+++ b/FE/src/atoms/shapeAtom.js
@@ -2,7 +2,7 @@ import { atom } from "recoil";
 
 const shapeAtom = atom({
   key: "shapeState",
-  default: {},
+  default: [],
 });
 
 export default shapeAtom;

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -1,11 +1,10 @@
-/* eslint-disable */
-
 import React, { useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
-import { useMutation, useQuery } from "react-query";
+import { useMutation } from "react-query";
 import styled from "styled-components";
 import userAtom from "../../atoms/userAtom";
 import diaryAtom from "../../atoms/diaryAtom";
+import shapeAtom from "../../atoms/shapeAtom";
 import ModalWrapper from "../../styles/Modal/ModalWrapper";
 import DiaryModalHeader from "../../styles/Modal/DiaryModalHeader";
 import deleteIcon from "../../assets/deleteIcon.svg";
@@ -26,7 +25,6 @@ function DiaryCreateModal(props) {
     tags: [],
     shapeUuid: "",
   });
-  const [newShapeData, setNewShapeData] = useState(null);
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
@@ -62,15 +60,6 @@ function DiaryCreateModal(props) {
     setDiaryData({ ...diaryData, tags: diaryData.tags.slice(0, -1) });
   };
 
-  async function getShapeFn() {
-    return fetch("http://223.130.129.145:3005/shapes/default", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }).then((res) => res.json());
-  }
-
   async function createDiaryFn(data) {
     return fetch("http://223.130.129.145:3005/diaries", {
       method: "POST",
@@ -89,56 +78,6 @@ function DiaryCreateModal(props) {
         }));
       });
   }
-
-  const {
-    data: shapeData,
-    // isLoading: shapeIsLoading,
-    // isError: shapeIsError,
-  } = useQuery("shape", getShapeFn, {
-    onSuccess: (dataList) => {
-      setDiaryData((prev) => ({ ...prev, shapeUuid: dataList[0].uuid }));
-      const newDataList = dataList.map((data) => {
-        const getPromise = () =>
-          fetch(`http://223.130.129.145:3005/shapes/${data.uuid}`, {
-            method: "GET",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${userState.accessToken}`,
-            },
-          });
-
-        return getPromise()
-          .then((res) => {
-            const reader = res.body.getReader();
-            return new ReadableStream({
-              start(controller) {
-                function pump() {
-                  return reader.read().then(({ done, value }) => {
-                    if (done) {
-                      controller.close();
-                      return;
-                    }
-                    controller.enqueue(value);
-                    return pump();
-                  });
-                }
-                return pump();
-              },
-            });
-          })
-          .then((stream) => new Response(stream))
-          .then((res) => res.blob())
-          .then((blob) => URL.createObjectURL(blob))
-          .then((url) => {
-            data.shapeData = url;
-          });
-      });
-
-      Promise.all(newDataList).then(() => {
-        setNewShapeData(dataList);
-      });
-    },
-  });
 
   const {
     mutate: createDiary,
@@ -197,10 +136,7 @@ function DiaryCreateModal(props) {
           }}
         />
       </DiaryModalTagWrapper>
-      <DiaryModalShapeSelectBox
-        shapeData={newShapeData}
-        setDiaryData={setDiaryData}
-      />
+      <DiaryModalShapeSelectBox setDiaryData={setDiaryData} />
       <ModalSideButtonWrapper>
         <ModalSideButton
           onClick={() => {
@@ -226,7 +162,8 @@ function DiaryCreateModal(props) {
 }
 
 function DiaryModalShapeSelectBox(props) {
-  const { shapeData, setDiaryData } = props;
+  const { setDiaryData } = props;
+  const shapeState = useRecoilValue(shapeAtom);
 
   return (
     <ShapeSelectBoxWrapper>
@@ -235,18 +172,15 @@ function DiaryModalShapeSelectBox(props) {
         <ShapeSelectText>직접 그리기</ShapeSelectText>
       </ShapeSelectTextWrapper>
       <ShapeSelectItemWrapper>
-        {shapeData?.map((shape) => (
+        {shapeState?.map((shape) => (
           <ShapeSelectBoxItem
             key={shape.uuid}
-            onClick={() =>
-              setDiaryData((prev) => ({ ...prev, shapeUuid: shape.uuid }))
-            }
+            onClick={() => {
+              console.log(shape.uuid);
+              setDiaryData((prev) => ({ ...prev, shapeUuid: shape.uuid }));
+            }}
           >
-            <img
-              src={shape.shapeData}
-              alt='shape'
-              style={{ width: "100%", height: "100%" }}
-            />
+            <div dangerouslySetInnerHTML={{ __html: shape.data }} />
           </ShapeSelectBoxItem>
         ))}
       </ShapeSelectItemWrapper>

--- a/FE/src/components/DiaryModal/DiaryCreateModal.js
+++ b/FE/src/components/DiaryModal/DiaryCreateModal.js
@@ -17,7 +17,7 @@ function DiaryCreateModal(props) {
   const setDiaryState = useSetRecoilState(diaryAtom);
 
   // TODO: 날짜 선택 기능 구현
-  const [diaryData, setDiaryData] = React.useState({
+  const [diaryData, setDiaryData] = useState({
     title: "",
     content: "",
     date: "2023-11-19",
@@ -176,7 +176,6 @@ function DiaryModalShapeSelectBox(props) {
           <ShapeSelectBoxItem
             key={shape.uuid}
             onClick={() => {
-              console.log(shape.uuid);
               setDiaryData((prev) => ({ ...prev, shapeUuid: shape.uuid }));
             }}
           >

--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import React, { useEffect, useLayoutEffect } from "react";
 import styled from "styled-components";
 import { useRecoilState } from "recoil";
@@ -19,6 +21,7 @@ function DiaryListModal() {
       setDiaryState((prev) => ({
         ...prev,
         diaryUuid: selectedDiary?.uuid,
+        diaryPoint: `${selectedDiary?.coordinate.x},${selectedDiary?.coordinate.y},${selectedDiary?.coordinate.z}`,
       }));
     }
   }, [selectedDiary]);

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -1,6 +1,4 @@
-/*eslint-disable*/
-
-import React, { useEffect } from "react";
+import React from "react";
 import { useQuery } from "react-query";
 import styled from "styled-components";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -64,12 +62,12 @@ function DiaryReadModal(props) {
     "diary",
     () => getDiary(userState.accessToken, diaryState.diaryUuid),
     {
-      onSuccess: (data) => {
-        const shapeData = shapeState.find((item) => {
-          return item.uuid === data.shapeUuid;
-        });
-        if (shapeData) {
-          setShapeData(shapeData.data);
+      onSuccess: (loadedData) => {
+        const foundShapeData = shapeState.find(
+          (item) => item.uuid === loadedData.shapeUuid,
+        );
+        if (foundShapeData) {
+          setShapeData(foundShapeData.data);
         }
       },
     },
@@ -162,7 +160,7 @@ function DiaryReadModal(props) {
           <div
             dangerouslySetInnerHTML={{ __html: shapeData }}
             style={{ width: "100%", height: "100%" }}
-          ></div>
+          />
         </DiaryModalIcon>
       </DiaryModalEmotionBar>
       {diaryState.isDelete ? <DiaryDeleteModal refetch={refetch} /> : null}

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -1,11 +1,12 @@
-/* eslint-disable */
+/*eslint-disable*/
 
-import React from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "react-query";
 import styled from "styled-components";
 import { useRecoilState, useRecoilValue } from "recoil";
 import diaryAtom from "../../atoms/diaryAtom";
 import userAtom from "../../atoms/userAtom";
+import shapeAtom from "../../atoms/shapeAtom";
 import ModalWrapper from "../../styles/Modal/ModalWrapper";
 import DiaryDeleteModal from "./DiaryDeleteModal";
 import editIcon from "../../assets/edit.svg";
@@ -57,46 +58,19 @@ function DiaryReadModal(props) {
   const { refetch } = props;
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
   const userState = useRecoilValue(userAtom);
+  const shapeState = useRecoilValue(shapeAtom);
   const [shapeData, setShapeData] = React.useState("");
   const { data, isLoading, isError } = useQuery(
     "diary",
     () => getDiary(userState.accessToken, diaryState.diaryUuid),
     {
-      onSuccess: (_data) => {
-        const getPromise = () =>
-          fetch(`http://223.130.129.145:3005/shapes/${_data.shapeUuid}`, {
-            method: "GET",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${userState.accessToken}`,
-            },
-          });
-
-        return getPromise()
-          .then((res) => {
-            const reader = res.body.getReader();
-            return new ReadableStream({
-              start(controller) {
-                function pump() {
-                  return reader.read().then(({ done, value }) => {
-                    if (done) {
-                      controller.close();
-                      return;
-                    }
-                    controller.enqueue(value);
-                    return pump();
-                  });
-                }
-                return pump();
-              },
-            });
-          })
-          .then((stream) => new Response(stream))
-          .then((res) => res.blob())
-          .then((blob) => URL.createObjectURL(blob))
-          .then((url) => {
-            setShapeData(url);
-          });
+      onSuccess: (data) => {
+        const shapeData = shapeState.find((item) => {
+          return item.uuid === data.shapeUuid;
+        });
+        if (shapeData) {
+          setShapeData(shapeData.data);
+        }
       },
     },
   );
@@ -185,14 +159,10 @@ function DiaryReadModal(props) {
           }}
         />
         <DiaryModalIcon>
-          <img
-            src={shapeData}
-            alt='star'
-            style={{
-              width: "5rem",
-              height: "5rem",
-            }}
-          />
+          <div
+            dangerouslySetInnerHTML={{ __html: shapeData }}
+            style={{ width: "100%", height: "100%" }}
+          ></div>
         </DiaryModalIcon>
       </DiaryModalEmotionBar>
       {diaryState.isDelete ? <DiaryDeleteModal refetch={refetch} /> : null}

--- a/FE/src/components/LoginModal/LoginModal.js
+++ b/FE/src/components/LoginModal/LoginModal.js
@@ -95,7 +95,9 @@ function LoginModal() {
             <input
               type='checkbox'
               checked={keepLogin}
-              onChange={setKeepLogin}
+              onChange={() => {
+                setKeepLogin((prev) => !prev);
+              }}
             />
             <div>로그인 유지</div>
           </CheckBar>

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -102,13 +102,6 @@ function MainPage() {
           }));
         }}
       />
-      {shapeState.map((shape) => (
-        <div
-          key={shape.uuid}
-          dangerouslySetInnerHTML={{ __html: shape.data }}
-        />
-      ))}
-
       <StarPage />
       {diaryState.isCreate ? <DiaryCreateModal refetch={refetch} /> : null}
       {diaryState.isRead ? <DiaryReadModal refetch={refetch} /> : null}

--- a/FE/src/pages/MainPage.js
+++ b/FE/src/pages/MainPage.js
@@ -1,7 +1,11 @@
+/* eslint-disable */
+
 import React, { useEffect } from "react";
 import styled from "styled-components";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState, useRecoilValue } from "recoil";
 import diaryAtom from "../atoms/diaryAtom";
+import shapeAtom from "../atoms/shapeAtom";
+import userAtom from "../atoms/userAtom";
 import DiaryCreateModal from "../components/DiaryModal/DiaryCreateModal";
 import DiaryReadModal from "../components/DiaryModal/DiaryReadModal";
 import background from "../assets/background.png";
@@ -11,6 +15,8 @@ import DiaryLoadingModal from "../components/DiaryModal/DiaryLoadingModal";
 
 function MainPage() {
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
+  const userState = useRecoilValue(userAtom);
+  const setShapeState = useSetRecoilState(shapeAtom);
 
   useEffect(() => {
     setDiaryState((prev) => {
@@ -24,6 +30,34 @@ function MainPage() {
       window.history.pushState(newState, "", "");
       return newState;
     });
+
+    async function getShapeFn() {
+      return fetch("http://223.130.129.145:3005/shapes/default", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then((res) => res.json())
+        .then(async (data) => {
+          const shapeDataList = data.map((shape) =>
+            fetch(`http://223.130.129.145:3005/shapes/${shape.uuid}`, {
+              method: "GET",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${userState.accessToken}`,
+              },
+            }).then(async (res) => ({
+              data: await res.text(),
+            })),
+          );
+
+          console.log(await Promise.all(shapeDataList));
+          setShapeState(await Promise.all(shapeDataList));
+        });
+    }
+
+    getShapeFn();
   }, []);
 
   return (
@@ -40,6 +74,20 @@ function MainPage() {
           }));
         }}
       />
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 100 100'
+        width='4rem'
+        height='4rem'
+      >
+        <defs>
+          <style>{`.cls-1{fill:none;stroke:gray;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.06px;}`}</style>
+        </defs>
+        <polygon
+          className='cls-1'
+          points='50 23.94 58.31 41.69 76.06 50 58.31 58.31 50 76.06 41.69 58.31 23.94 50 41.69 41.69 50 23.94'
+        />
+      </svg>
       {diaryState.isCreate ? <DiaryCreateModal /> : null}
       {diaryState.isRead ? <DiaryReadModal /> : null}
       {diaryState.isUpdate ? <DiaryUpdateModal /> : null}


### PR DESCRIPTION
## 요약

### 기존 일기 작성 / 읽기에 사용되던 이미지 png에서 svg로 변경
### 일기 수정에 사용되는 이미지 구현
### 리스트 보기에서 일기 수정 적용 안 되는 버그 수정

## 변경 사항

- 일기 모양의 데이터가 png에서 svg로 변경되면서 바뀐 로직을 각 사용처에 적용하였습니다.
- 리스트보기에서 일기 수정이 안 되는 버그를 수정하였습니다.
  - 리스트보기에서 수정 시 일기 좌표를 저장하지 않는 이슈가 있어 해당 부분 수정하였습니다.
- Mainpage에 접속 시 각 모양을 가져와서 shapeAtom에 저장 후 각 사용처에 알맞게 사용하도록 구현하였습니다.

## 이슈 번호

close #168 
