### PR TITLE
[Deploy] docker compose up 명령 실행 시 --build 옵션 제거

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -51,5 +51,5 @@ jobs:
             cd /home/docker-byeolsoop/srcs
             docker system prune -f
             docker pull byeolsoop-registry.kr.ncr.ntruss.com/backend:byeolsoop
-            docker compose up --force-recreate --build -d 2>log.out
+            docker compose up --force-recreate -d 2>log.out
             cat log.out

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -51,5 +51,5 @@ jobs:
             cd /home/docker-byeolsoop/srcs
             docker system prune -f
             docker pull byeolsoop-registry.kr.ncr.ntruss.com/frontend:byeolsoop
-            docker compose up --force-recreate --build -d 2>log.out
+            docker compose up --force-recreate -d 2>log.out
             cat log.out


### PR DESCRIPTION
## 요약

docker compose up 명령 실행 시 --build 옵션 제거

## 변경 사항

`docker compose up --force-recreate -d 2>log.out` 에서 --build 옵션 제거
- `build` 옵션은 Docker Compose에게 서비스에 대한 이미지를 강제로 다시 빌드하도록 지시
- pull로 받아온 이미지가 아닌 새로운 이미지를 생성함

## 참고 사항

- Dockerfile에서 어짜피 git pull을 하고 있는데 반영이 왜 안되었는지는 아직 모르겠음..!

## 이슈 번호

- #165
