### PR TITLE
[Feat] 연도별 태그 순위 API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -10,6 +10,7 @@ import { ShapesRepository } from "./shapes/shapes.repository";
 import { UsersRepository } from "./auth/users.repository";
 import { typeORMTestConfig } from "./configs/typeorm.test.config";
 import { RedisModule } from "@liaoliaots/nestjs-redis";
+import { StatModule } from './stat/stat.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { RedisModule } from "@liaoliaots/nestjs-redis";
     AuthModule,
     IntroduceModule,
     ShapesModule,
+    StatModule,
   ],
   providers: [ShapesRepository, UsersRepository],
 })

--- a/BE/src/stat/dto/stat.tags.dto.ts
+++ b/BE/src/stat/dto/stat.tags.dto.ts
@@ -1,0 +1,9 @@
+export class TagInfo {
+  id: number;
+  count: number;
+  tag: string;
+}
+
+export class StatTagDto {
+  [key: string]: { rank: number } & TagInfo;
+}

--- a/BE/src/stat/dto/stat.tags.dto.ts
+++ b/BE/src/stat/dto/stat.tags.dto.ts
@@ -1,9 +1,9 @@
-export class TagInfo {
+export class TagInfoDto {
   id: number;
   count: number;
   tag: string;
 }
 
 export class StatTagDto {
-  [key: string]: { rank: number } & TagInfo;
+  [key: string]: ({ rank: number } & TagInfoDto) | {};
 }

--- a/BE/src/stat/stat.controller.ts
+++ b/BE/src/stat/stat.controller.ts
@@ -1,0 +1,25 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+} from "@nestjs/common";
+import { GetUser } from "src/auth/get-user.decorator";
+import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
+import { User } from "src/auth/users.entity";
+import { StatService } from "./stat.service";
+
+@Controller("stat")
+@UseGuards(JwtAuthGuard)
+export class StatController {
+  constructor(private statService: StatService) {}
+
+  @Get("/tags-rank/:year")
+  async getTagsRank(
+    @Param("year", ParseIntPipe) year: number,
+    @GetUser() user: User,
+  ): Promise<Object> {
+    return this.statService.getTopThreeTagsByUser(year, user.id);
+  }
+}

--- a/BE/src/stat/stat.controller.ts
+++ b/BE/src/stat/stat.controller.ts
@@ -9,6 +9,7 @@ import { GetUser } from "src/auth/get-user.decorator";
 import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
 import { User } from "src/auth/users.entity";
 import { StatService } from "./stat.service";
+import { StatTagDto } from "./dto/stat.tags.dto";
 
 @Controller("stat")
 @UseGuards(JwtAuthGuard)
@@ -19,7 +20,7 @@ export class StatController {
   async getTagsRank(
     @Param("year", ParseIntPipe) year: number,
     @GetUser() user: User,
-  ): Promise<Object> {
+  ): Promise<StatTagDto> {
     return this.statService.getTopThreeTagsByUser(year, user.id);
   }
 }

--- a/BE/src/stat/stat.module.ts
+++ b/BE/src/stat/stat.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { StatController } from "./stat.controller";
+import { StatService } from "./stat.service";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Diary } from "src/diaries/diaries.entity";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Diary])],
+  controllers: [StatController],
+  providers: [StatService],
+})
+export class StatModule {}

--- a/BE/src/stat/stat.service.ts
+++ b/BE/src/stat/stat.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { Diary } from "src/diaries/diaries.entity";
-import { StatTagDto, TagInfo } from "./dto/stat.tags.dto";
+import { StatTagDto, TagInfoDto } from "./dto/stat.tags.dto";
 
 @Injectable()
 export class StatService {
@@ -8,14 +8,17 @@ export class StatService {
     year: number,
     userId: number,
   ): Promise<StatTagDto> {
-    const result: TagInfo[] = await this.fetchTopThreeTagsByUser(year, userId);
+    const result: TagInfoDto[] = await this.fetchTopThreeTagsByUser(
+      year,
+      userId,
+    );
     return this.getFormatResult(result);
   }
 
   private async fetchTopThreeTagsByUser(
     year: number,
     userId: number,
-  ): Promise<TagInfo[]> {
+  ): Promise<TagInfoDto[]> {
     return await Diary.createQueryBuilder("diary")
       .select("tags.name", "tag")
       .addSelect("tags.id", "id")
@@ -30,7 +33,7 @@ export class StatService {
       .getRawMany();
   }
 
-  private getFormatResult(result: TagInfo[]): StatTagDto {
+  private getFormatResult(result: TagInfoDto[]): StatTagDto {
     const keys = ["first", "second", "third"];
     const formattedResult = {};
     result.forEach((item, index) => {

--- a/BE/src/stat/stat.service.ts
+++ b/BE/src/stat/stat.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from "@nestjs/common";
+import { Diary } from "src/diaries/diaries.entity";
+import { StatTagDto, TagInfo } from "./dto/stat.tags.dto";
+
+@Injectable()
+export class StatService {
+  async getTopThreeTagsByUser(
+    year: number,
+    userId: number,
+  ): Promise<StatTagDto> {
+    const result: TagInfo[] = await this.fetchTopThreeTagsByUser(year, userId);
+    return this.getFormatResult(result);
+  }
+
+  private async fetchTopThreeTagsByUser(
+    year: number,
+    userId: number,
+  ): Promise<TagInfo[]> {
+    return await Diary.createQueryBuilder("diary")
+      .select("tags.name", "tag")
+      .addSelect("tags.id", "id")
+      .addSelect("COUNT(*)", "count")
+      .innerJoin("diary.tags", "tags")
+      .where("diary.user = :userId", { userId })
+      .andWhere("YEAR(diary.date) = :year", { year })
+      .groupBy("tags.name")
+      .addGroupBy("tags.id")
+      .orderBy("count", "DESC")
+      .take(3)
+      .getRawMany();
+  }
+
+  private getFormatResult(result: TagInfo[]): StatTagDto {
+    const keys = ["first", "second", "third"];
+    const formattedResult = {};
+    result.forEach((item, index) => {
+      const rank = index + 1;
+      formattedResult[keys[index]] = { rank, ...item };
+    });
+
+    return formattedResult;
+  }
+}

--- a/BE/test/int/stat.service.int-spec.ts
+++ b/BE/test/int/stat.service.int-spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { Diary } from "src/diaries/diaries.entity";
+import { StatService } from "src/stat/stat.service";
+
+describe("StatService 통합 테스트", () => {
+  let service: StatService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StatService],
+    }).compile();
+
+    service = module.get<StatService>(StatService);
+  });
+
+  describe("getTopThreeTagsByUser 메서드", () => {
+    it("메서드 정상 요청", async () => {
+      const year = 2023;
+      const userId = 1;
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { tag: "태그1", id: 1, count: 10 },
+          { tag: "태그2", id: 2, count: 9 },
+          { tag: "태그3", id: 3, count: 8 },
+        ]),
+      };
+
+      jest
+        .spyOn(Diary, "createQueryBuilder")
+        .mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getTopThreeTagsByUser(year, userId);
+
+      expect(result).toEqual({
+        first: { rank: 1, tag: "태그1", id: 1, count: 10 },
+        second: { rank: 2, tag: "태그2", id: 2, count: 9 },
+        third: { rank: 3, tag: "태그3", id: 3, count: 8 },
+      });
+    });
+  });
+});

--- a/BE/test/int/stat.service.int-spec.ts
+++ b/BE/test/int/stat.service.int-spec.ts
@@ -5,7 +5,7 @@ import { StatService } from "src/stat/stat.service";
 describe("StatService 통합 테스트", () => {
   let service: StatService;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [StatService],
     }).compile();


### PR DESCRIPTION
## 요약

- `/stat/tags-rank/:year` `GET` API 구현
  - 해당 연도에 태그가 없거나, 태그가 적다면 1~3위가 모두 반환되지 않을 수 있음

## 변경 사항

### 연도별 태그 순위 API 구현

- StatModule, Controller, Service 틀 정의
  - 컨트롤러에 `@UseGuards(JwtAuthGuard)` 사용
- stat.tags.dto 정의
- `/stat/tags-rank/:year` `GET` API 구현
  - year에 대한 Param을 받을 때 ParseIntPipe를 활용하여 정수 데이터로 변환
    - 숫자가 아닌 문자열, 소수점에 대한 데이터 전송 시 400 Bad Request를 반환
  - 태그가 없는 일기가 있어도 정상 동작
-  repository를 따로 구현하지 않고 service 단에서 DB 통신 코드 작성
  - 이유: 여러 테이블을 조인하고 복잡한 집계 쿼리를 실행하는 비즈니스 로직을 수행하기 때문

### getTopThreeTagsByUser 메서드에 대한 통합 테스트 작성
- DB와 연동하는 코드를 작성하고 싶었으나, DB에 따라 테스트 결과가 달라짐
- 따라서 mocking으로 처리
  - class에서 private으로 처리된 fetchTopThreeTagsByUser 함수는 mocking 불가능
  - 따라서 QueryBuilder를 mocking


### 실행 결과

- 성공 응답
 
<img width="400" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/f80def7b-f2f2-4fa2-971c-013dbfc88f96">

<img width="400" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/1dc93868-fd24-49c6-90e3-09a088016b56">

<img width="400" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/f4a2a640-1c9b-4650-b73b-675af2836f30">



- year에 대한 타입 에러

<img width="400" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/2ebd3a6c-9025-483b-8b64-07ed108b0417">

<img width="400" alt="스크린샷 2023-11-29 오후 11 28 22" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/d1500d09-2146-4eb2-841b-a369bbf75cb5">


## 참고 사항

- StatService의 역할이 많아질 경우, 모양과 태그 각각의 독립된 서비스로 분리하는 방향도 고민중에 있음
- `mockQueryBuilder` 타입을 `as any`로 설정한 이유
  - TypeORM의 createQueryBuilder 메서드는 SelectQueryBuilder 인스턴스를 반환하므로, 이를 모방하기 위한 mock 객체는 SelectQueryBuilder의 모든 메서드와 속성을 가지고 있어야 함 
  - 하지만, 현재는 필요한 메서드만 구현하였기 때문에 타입 에러가 발생
  - any 타입의 값을 반환하도록 설정하여 TypeScript의 타입 검사를 우회

## 이슈 번호

- close #169
