### PR TITLE
[Hotfix] 감정 분석 결과 저장 오류 수정

### DIFF
--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -28,7 +28,7 @@ export class DiariesRepository {
     const positiveRatio = sentimentResult.positiveRatio;
     const negativeRatio = sentimentResult.negativeRatio;
     const neutralRatio = sentimentResult.neutralRatio;
-    const sentiment = sentimentStatus[sentimentResult.sentiment];
+    const sentiment = sentimentResult.sentiment;
 
     const newDiary = Diary.create({
       title,

--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -31,8 +31,9 @@ export class DiariesService {
     const shape = await this.shapesRepository.getShapeByUuid(shapeUuid);
     const encryptedContent = this.getEncryptedContent(content);
     const tagEntities = await this.getTags(tags);
-    const sentimentResult = await this.getSentiment(content);
+    const sentimentResult: SentimentDto = await this.getSentiment(content);
 
+    console.log(sentimentResult);
     const diary = await this.diariesRepository.createDiary(
       createDiaryDto,
       encryptedContent,
@@ -167,11 +168,12 @@ export class DiariesService {
     const sentiment = (await sentimentResponse).data.document.sentiment;
 
     const result: SentimentDto = {
-      positiveRatio,
-      neutralRatio,
-      negativeRatio,
-      sentiment,
+      positiveRatio: positiveRatio,
+      neutralRatio: neutralRatio,
+      negativeRatio: negativeRatio,
+      sentiment: sentimentStatus[sentiment.toUpperCase()],
     };
+
     return result;
   }
 


### PR DESCRIPTION
## 요약

- 감정 분석 결과가 정상적으로 저장되지 않는 오류 수정

## 변경 사항

### 감정 분석 결과가 정상적으로 저장되지 않는 오류 수정
- sentimentStatus의 양식으로 넣어야 하는 sentimentDto의 sentiment 값에 일반 string을 넣어 undefined 값이 넘어가게 됨
- 결과적으로 save시 undefined 값이 엔티티에 전송되어 기본 값인 ERROR를 저장하게 되었음
- 현재는 sentimentStatus 형식에 맞는 형태로 수정하여 정상 작동중


## 참고 사항

- 없음

## 이슈 번호

없음
