### PR TITLE
[Feat] 별자리선 Entity 생성 및 API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -11,6 +11,7 @@ import { UsersRepository } from "./auth/users.repository";
 import { typeORMTestConfig } from "./configs/typeorm.test.config";
 import { RedisModule } from "@liaoliaots/nestjs-redis";
 import { StatModule } from './stat/stat.module';
+import { LinesModule } from './lines/lines.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { StatModule } from './stat/stat.module';
     IntroduceModule,
     ShapesModule,
     StatModule,
+    LinesModule,
   ],
   providers: [ShapesRepository, UsersRepository],
 })

--- a/BE/src/diaries/diaries.controller.ts
+++ b/BE/src/diaries/diaries.controller.ts
@@ -21,8 +21,8 @@ import { ReadDiaryDto, ReadDiaryResponseDto } from "./dto/diaries.read.dto";
 import { PrivateDiaryGuard } from "src/auth/guard/auth.diary-guard";
 import { GetUser } from "src/auth/get-user.decorator";
 import { User } from "src/auth/users.entity";
-import { Tag } from "src/tags/tags.entity";
 import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
+import { getReadResponseDtoFormat } from "src/utils/data-transform";
 
 @Controller("diaries")
 @UseGuards(JwtAuthGuard)
@@ -48,7 +48,7 @@ export class DiariesController {
     const readDiaryDto: ReadDiaryDto = { uuid };
     const diary = await this.diariesService.readDiary(readDiaryDto);
 
-    return this.getReadResponseDtoFormat(diary);
+    return getReadResponseDtoFormat(diary);
   }
 
   @Get()
@@ -57,7 +57,7 @@ export class DiariesController {
   ): Promise<ReadDiaryResponseDto[]> {
     const diaryList = await this.diariesService.readDiariesByUser(user);
     const readDiaryResponseDtoList = diaryList.map((diary) =>
-      this.getReadResponseDtoFormat(diary),
+      getReadResponseDtoFormat(diary),
     );
 
     return readDiaryResponseDtoList;
@@ -81,41 +81,5 @@ export class DiariesController {
     const deleteDiaryDto: DeleteDiaryDto = { uuid };
     await this.diariesService.deleteDiary(deleteDiaryDto);
     return;
-  }
-
-  getTagNames(tags: Tag[]): string[] {
-    const tagNames = tags.map((tag) => tag.name);
-    return tagNames;
-  }
-
-  getCoordinate(point: string): { x: number; y: number; z: number } {
-    const [x, y, z] = point.split(",");
-    return {
-      x: parseFloat(x),
-      y: parseFloat(y),
-      z: parseFloat(z),
-    };
-  }
-
-  getReadResponseDtoFormat(diary: Diary): ReadDiaryResponseDto {
-    const tagNames = this.getTagNames(diary.tags);
-    const coordinate = this.getCoordinate(diary.point);
-
-    return {
-      coordinate,
-      uuid: diary.uuid,
-      userId: diary.user.userId,
-      title: diary.title,
-      content: diary.content,
-      date: diary.date,
-      tags: tagNames,
-      emotion: {
-        positive: diary.positiveRatio,
-        neutral: diary.neutralRatio,
-        negative: diary.negativeRatio,
-        sentiment: diary.sentiment,
-      },
-      shapeUuid: diary.shape.uuid,
-    };
   }
 }

--- a/BE/src/lines/dto/lines.dto.ts
+++ b/BE/src/lines/dto/lines.dto.ts
@@ -9,3 +9,9 @@ export class CreateLineDto {
   @IsNotEmpty({ message: "별자리선 uuid2는 비어있지 않아야 합니다." })
   uuid2: string;
 }
+
+export class ReadLineDto {
+  id: number;
+  first: { uuid: string; coordinate: { x: number; y: number; z: number } };
+  second: { uuid: string; coordinate: { x: number; y: number; z: number } };
+}

--- a/BE/src/lines/dto/lines.dto.ts
+++ b/BE/src/lines/dto/lines.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsUUID } from "class-validator";
+
+export class CreateLineDto {
+  @IsUUID("4", { message: "별자리선 uuid1 값이 uuid 양식이어야 합니다." })
+  @IsNotEmpty({ message: "별자리선 uuid1는 비어있지 않아야 합니다." })
+  uuid1: string;
+
+  @IsUUID("4", { message: "별자리선 uuid2 값이 uuid 양식이어야 합니다." })
+  @IsNotEmpty({ message: "별자리선 uuid2는 비어있지 않아야 합니다." })
+  uuid2: string;
+}

--- a/BE/src/lines/lines.controller.ts
+++ b/BE/src/lines/lines.controller.ts
@@ -1,10 +1,18 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
 import { LinesService } from "./lines.service";
-import { CreateLineDto } from "./dto/lines.dto";
+import { CreateLineDto, ReadLineDto } from "./dto/lines.dto";
 import { GetUser } from "src/auth/get-user.decorator";
 import { User } from "src/auth/users.entity";
 import { Line } from "./lines.entity";
+import { getReadLineDtoFormat } from "src/utils/data-transform";
 
 @Controller("lines")
 @UseGuards(JwtAuthGuard)
@@ -19,5 +27,16 @@ export class LinesController {
   ): Promise<{ id: number }> {
     const line: Line = await this.linesService.createLine(createLineDto, user);
     return { id: line.id };
+  }
+
+  @Get()
+  async getLinesByUser(@GetUser() user: User): Promise<ReadLineDto[]> {
+    const lines: Line[] = await this.linesService.getLinesByUser(user);
+
+    const readLineDtoList: ReadLineDto[] = lines.map((line) =>
+      getReadLineDtoFormat(line),
+    );
+
+    return readLineDtoList;
   }
 }

--- a/BE/src/lines/lines.controller.ts
+++ b/BE/src/lines/lines.controller.ts
@@ -1,8 +1,11 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
+  Param,
+  ParseIntPipe,
   Post,
   UseGuards,
 } from "@nestjs/common";
@@ -38,5 +41,15 @@ export class LinesController {
     );
 
     return readLineDtoList;
+  }
+
+  @Delete("/:id")
+  @HttpCode(204)
+  async deleteLine(
+    @Param("id", ParseIntPipe) id: number,
+    @GetUser() user: User,
+  ): Promise<void> {
+    await this.linesService.deleteLine(id, user);
+    return;
   }
 }

--- a/BE/src/lines/lines.controller.ts
+++ b/BE/src/lines/lines.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
+import { LinesService } from "./lines.service";
+import { CreateLineDto } from "./dto/lines.dto";
+import { GetUser } from "src/auth/get-user.decorator";
+import { User } from "src/auth/users.entity";
+import { Line } from "./lines.entity";
+
+@Controller("lines")
+@UseGuards(JwtAuthGuard)
+export class LinesController {
+  constructor(private linesService: LinesService) {}
+
+  @Post()
+  @HttpCode(201)
+  async createLine(
+    @Body() createLineDto: CreateLineDto,
+    @GetUser() user: User,
+  ): Promise<{ id: number }> {
+    const line: Line = await this.linesService.createLine(createLineDto, user);
+    return { id: line.id };
+  }
+}

--- a/BE/src/lines/lines.entity.ts
+++ b/BE/src/lines/lines.entity.ts
@@ -1,3 +1,4 @@
+import { User } from "src/auth/users.entity";
 import { Diary } from "src/diaries/diaries.entity";
 import {
   BaseEntity,
@@ -12,10 +13,21 @@ export class Line extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
-  @ManyToOne(() => Diary, (diary) => diary.id)
+  @ManyToOne(() => Diary, (diary) => diary.id, {
+    nullable: false,
+    eager: true,
+  })
   firstDiary: Diary;
 
-  @ManyToOne(() => Diary, (diary) => diary.id)
+  @ManyToOne(() => Diary, (diary) => diary.id, {
+    nullable: false,
+    eager: true,
+  })
   secondDiary: Diary;
+
+  @ManyToOne(() => User, (user) => user.id, {
+    nullable: false,
+    eager: true,
+  })
+  user: User;
 }

--- a/BE/src/lines/lines.entity.ts
+++ b/BE/src/lines/lines.entity.ts
@@ -3,6 +3,8 @@ import { Diary } from "src/diaries/diaries.entity";
 import {
   BaseEntity,
   Column,
+  CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -30,4 +32,10 @@ export class Line extends BaseEntity {
     eager: true,
   })
   user: User;
+
+  @CreateDateColumn({ type: "datetime" })
+  createdDate: Date;
+
+  @DeleteDateColumn({ type: "datetime" })
+  deletedDate: Date;
 }

--- a/BE/src/lines/lines.entity.ts
+++ b/BE/src/lines/lines.entity.ts
@@ -1,0 +1,21 @@
+import { Diary } from "src/diaries/diaries.entity";
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+@Entity({ name: "constellation" })
+export class Line extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  @ManyToOne(() => Diary, (diary) => diary.id)
+  firstDiary: Diary;
+
+  @ManyToOne(() => Diary, (diary) => diary.id)
+  secondDiary: Diary;
+}

--- a/BE/src/lines/lines.module.ts
+++ b/BE/src/lines/lines.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { LinesController } from "./lines.controller";
+import { LinesService } from "./lines.service";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Line } from "./lines.entity";
+import { DiariesModule } from "src/diaries/diaries.module";
+import { DiariesRepository } from "src/diaries/diaries.repository";
+import { LinesRepository } from "./lines.repository";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Line]), DiariesModule],
+  controllers: [LinesController],
+  providers: [LinesService, LinesRepository, DiariesRepository],
+})
+export class LinesModule {}

--- a/BE/src/lines/lines.repository.ts
+++ b/BE/src/lines/lines.repository.ts
@@ -19,7 +19,7 @@ export class LinesRepository {
     return newLine;
   }
 
-  async readLinesByUser(user: User): Promise<Line[]> {
+  async fetchLinesByUser(user: User): Promise<Line[]> {
     const linesList = await Line.find({
       where: { user: { id: user.id } },
     });

--- a/BE/src/lines/lines.repository.ts
+++ b/BE/src/lines/lines.repository.ts
@@ -1,0 +1,43 @@
+import { Diary } from "src/diaries/diaries.entity";
+import { Line } from "./lines.entity";
+import { User } from "src/auth/users.entity";
+import { NotFoundException } from "@nestjs/common";
+
+export class LinesRepository {
+  async createLine(
+    firstDiary: Diary,
+    secondDiary: Diary,
+    user: User,
+  ): Promise<Line> {
+    const newLine = Line.create({
+      firstDiary,
+      secondDiary,
+      user,
+    });
+    await newLine.save();
+
+    return newLine;
+  }
+
+  async readLinesByUser(user: User): Promise<Line[]> {
+    const linesList = await Line.find({
+      where: { user: { id: user.id } },
+    });
+    return linesList;
+  }
+
+  async deleteDiary(id: number): Promise<void> {
+    const diary = await this.getLineById(id);
+
+    await Line.softRemove(diary);
+  }
+
+  async getLineById(id: number): Promise<Line> {
+    const found = await Line.findOne({ where: { id } });
+    if (!found) {
+      throw new NotFoundException("존재하지 않는 별자리선입니다.");
+    }
+
+    return found;
+  }
+}

--- a/BE/src/lines/lines.repository.ts
+++ b/BE/src/lines/lines.repository.ts
@@ -26,10 +26,9 @@ export class LinesRepository {
     return linesList;
   }
 
-  async deleteDiary(id: number): Promise<void> {
-    const diary = await this.getLineById(id);
-
-    await Line.softRemove(diary);
+  async deleteLine(id: number): Promise<void> {
+    const line = await this.getLineById(id);
+    await Line.softRemove(line);
   }
 
   async getLineById(id: number): Promise<Line> {

--- a/BE/src/lines/lines.service.ts
+++ b/BE/src/lines/lines.service.ts
@@ -45,6 +45,10 @@ export class LinesService {
     return this.linesRepository.createLine(firstDiary, secondDiary, user);
   }
 
+  async getLinesByUser(user: User): Promise<Line[]> {
+    return this.linesRepository.fetchLinesByUser(user);
+  }
+
   private async isDuplicateLine(
     firstDiary: Diary,
     secondDiary: Diary,

--- a/BE/src/lines/lines.service.ts
+++ b/BE/src/lines/lines.service.ts
@@ -49,6 +49,15 @@ export class LinesService {
     return this.linesRepository.fetchLinesByUser(user);
   }
 
+  async deleteLine(id: number, user: User): Promise<void> {
+    const line = await this.linesRepository.getLineById(id);
+    if (line.user.id !== user.id) {
+      throw new NotFoundException("존재하지 않는 별자리선입니다.");
+    }
+
+    await this.linesRepository.deleteLine(id);
+  }
+
   private async isDuplicateLine(
     firstDiary: Diary,
     secondDiary: Diary,

--- a/BE/src/lines/lines.service.ts
+++ b/BE/src/lines/lines.service.ts
@@ -1,0 +1,70 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { CreateLineDto } from "./dto/lines.dto";
+import { User } from "src/auth/users.entity";
+import { Line } from "./lines.entity";
+import { LinesRepository } from "./lines.repository";
+import { DiariesRepository } from "src/diaries/diaries.repository";
+import { Diary } from "src/diaries/diaries.entity";
+
+@Injectable()
+export class LinesService {
+  constructor(
+    private linesRepository: LinesRepository,
+    private diariesRepository: DiariesRepository,
+  ) {}
+
+  async createLine(createLineDto: CreateLineDto, user: User): Promise<Line> {
+    const { uuid1, uuid2 } = createLineDto;
+
+    if (uuid1 === uuid2) {
+      throw new BadRequestException(
+        "동일한 일기에 별자리선을 생성할 수 없습니다.",
+      );
+    }
+
+    const firstDiary = await this.diariesRepository.getDiaryByUuid(uuid1);
+    const secondDiary = await this.diariesRepository.getDiaryByUuid(uuid2);
+
+    const isDuplicate = await this.isDuplicateLine(
+      firstDiary,
+      secondDiary,
+      user,
+    );
+    if (isDuplicate) {
+      throw new BadRequestException("이미 존재하는 별자리선입니다.");
+    }
+
+    if (firstDiary.user.id !== user.id || secondDiary.user.id !== user.id) {
+      throw new NotFoundException("존재하지 않는 일기입니다.");
+    }
+
+    return this.linesRepository.createLine(firstDiary, secondDiary, user);
+  }
+
+  private async isDuplicateLine(
+    firstDiary: Diary,
+    secondDiary: Diary,
+    user: User,
+  ): Promise<boolean> {
+    const existingLine = await Line.findOne({
+      where: [
+        {
+          firstDiary: { id: firstDiary.id },
+          secondDiary: { id: secondDiary.id },
+          user: { id: user.id },
+        },
+        {
+          firstDiary: { id: secondDiary.id },
+          secondDiary: { id: firstDiary.id },
+          user: { id: user.id },
+        },
+      ],
+    });
+
+    return !!existingLine;
+  }
+}

--- a/BE/src/utils/data-transform.ts
+++ b/BE/src/utils/data-transform.ts
@@ -1,0 +1,61 @@
+import { Diary } from "src/diaries/diaries.entity";
+import { ReadDiaryResponseDto } from "src/diaries/dto/diaries.read.dto";
+import { ReadLineDto } from "src/lines/dto/lines.dto";
+import { Line } from "src/lines/lines.entity";
+import { Tag } from "src/tags/tags.entity";
+
+export function getTagNames(tags: Tag[]): string[] {
+  const tagNames = tags.map((tag) => tag.name);
+  return tagNames;
+}
+
+export function getCoordinate(point: string): {
+  x: number;
+  y: number;
+  z: number;
+} {
+  const [x, y, z] = point.split(",");
+  return {
+    x: parseFloat(x),
+    y: parseFloat(y),
+    z: parseFloat(z),
+  };
+}
+
+export function getReadResponseDtoFormat(diary: Diary): ReadDiaryResponseDto {
+  const tagNames = getTagNames(diary.tags);
+  const coordinate = getCoordinate(diary.point);
+
+  return {
+    coordinate,
+    uuid: diary.uuid,
+    userId: diary.user.userId,
+    title: diary.title,
+    content: diary.content,
+    date: diary.date,
+    tags: tagNames,
+    emotion: {
+      positive: diary.positiveRatio,
+      neutral: diary.neutralRatio,
+      negative: diary.negativeRatio,
+      sentiment: diary.sentiment,
+    },
+    shapeUuid: diary.shape.uuid,
+  };
+}
+
+export function getReadLineDtoFormat(line: Line): ReadLineDto {
+  const { id, firstDiary, secondDiary } = line;
+
+  return {
+    id,
+    first: {
+      uuid: firstDiary.uuid,
+      coordinate: getCoordinate(firstDiary.point),
+    },
+    second: {
+      uuid: secondDiary.uuid,
+      coordinate: getCoordinate(secondDiary.point),
+    },
+  };
+}


### PR DESCRIPTION
## 요약

- Line Entity 생성
- 데이터 변환 함수 파일 모듈화
- 별자리선 API 구현

## 변경 사항

### Line Entity 생성

- 테이블명은 constellation로 지정
- 특정 유저가 사용한 별자리선 조회 구현을 위해 user 컬럼 추가
- 별자리선 soft delete 구현을 위해 deletedDate 컬럼 추가

### 데이터 변환 함수 파일 모듈화

- diariesController에서 응답 형식으로 데이터를 변환하는 코드를 `utils/data-transform.ts` 로 이동
- 별자리선 조회 응답 형식으로 변환해주는 `getReadLineDtoFormat` 함수 구현

### 별자리선 API 구현
1. 별자리선 생성
- `/lines POST`
- 정상 요청 시 201 Created 및 id 반환
- 중복된 별자리선 생성 요청 시 400 Bad Request
- 동일한 uuid 요청 시 400 Bad Request
- 존재하지 않는 별에 대해 요청 시 400 Bad Request
- 권한 에러: 401 Unauthorized

2. 별자리선 조회
- `/lines GET`
- 로그인한 유저의 별자리선 조회
- 정상 요청 시 200 OK 및 body에 `ReadLineDto[]` 타입으로 반환
- 권한 에러: 401 Unauthorized

3. 별자리선 삭제
- `/lines/:id DELETE`
- 삭제 성공 시 204 No Content
- 타인의 별자리선 삭제 요청 시 404 Not Found
- 존재하지 않는 별자리선 삭제 요청 시 404 Not Found
- 권한 에러: 401 Unauthorized

## 스크린샷

- 별자리선 생성 정상 요청

<img width="600" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/c23f2bb1-08cd-4645-b2da-42478fdd9131" >

- 별자리선 생성 중복 요청

<img width="600" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/bc2d53e6-5e38-42e2-9ba6-c553ec0cb47f" >

- 별자리선 조회 요청

<img width="600" alt="스크린샷 2023-11-30 오후 5 21 02" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/100fb2a5-28d8-462e-9419-81eb9e87ec2e">

- 별자리선 삭제 요청

<img width="600" alt="스크린샷 2023-11-30 오후 5 23 30" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/f5377b02-0d7e-4070-a2dd-20551fbff9d9">

- 이미 삭제된 별자리선 삭제 요청

<img width="600" src="https://github.com/boostcampwm2023/web08-ByeolSoop/assets/44529556/699fec6f-2976-4eb2-97b5-a4aad807699b" >

## 참고 사항

- 테스트코드는 추가로 작성하도록 하겠습니다!

## 이슈 번호

- #178
