### PR TITLE
[Hotfix] 만료된 액세스 토큰으로 요청 시 성공하도록 수정

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -49,10 +49,7 @@ export class AuthController {
   @Post("/reissue")
   @UseGuards(ExpiredOrNotGuard)
   @HttpCode(201)
-  async reissueAccessToken(
-    @GetUser() user: User,
-    @Req() request: Request,
-  ): Promise<AccessTokenDto> {
-    return await this.authService.reissueAccessToken(user, request);
+  async reissueAccessToken(@Req() request: Request): Promise<AccessTokenDto> {
+    return await this.authService.reissueAccessToken(request);
   }
 }

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -86,6 +86,5 @@ export class AuthService {
     await this.redisClient.set(userId, refreshToken, "EX", 86400);
 
     return new AccessTokenDto(accessToken);
-    return new AccessTokenDto("123151");
   }
 }


### PR DESCRIPTION


## 요약

- 만료된 액세스 토큰으로 요청 시 성공하도록 수정

## 변경 사항

### 만료된 액세스 토큰으로 요청 시 성공하도록 수정
- 액세스 토큰이 아니라 헤더에서 사용자 아이디를 추출함으로써 만료된 액세스 토큰으로 요청 시 성공하도록 수정
- 기존에는 만료된 액세스 토큰에서 사용자 아이디 추출을 시도하여, 사용자 아이디가 undefined가 된 상태로 새로운 액세스 토큰이 발급되었다. 따라서 새로 발급된 액세스 토큰을 사용하면 사용자 아이디를 읽을 수 없는 문제가 있었다.

## 참고 사항

- 없음

## 이슈 번호

없음
