### PR TITLE
[Hotfix] 일기 수정 시 에러 발생 수정, 3D view 일부 변경

### DIFF
--- a/FE/src/components/DiaryModal/DiaryUpdateModal.js
+++ b/FE/src/components/DiaryModal/DiaryUpdateModal.js
@@ -99,26 +99,26 @@ function DiaryUpdateModal(props) {
   } = useMutation(updateDiaryFn);
 
   const {
-    // data: originData,
+    data: originData,
     isLoading,
     isError,
-  } = useQuery(
-    "diary",
-    () => getDiary(userState.accessToken, diaryState.diaryUuid),
-    {
-      onSuccess: (data) => {
-        setDiaryData({
-          ...diaryData,
-          title: data.title,
-          content: data.content,
-          date: data.date,
-          tags: data.tags,
-        });
-        titleRef.current.value = data.title;
-        contentRef.current.value = data.content;
-      },
-    },
+  } = useQuery("diary", () =>
+    getDiary(userState.accessToken, diaryState.diaryUuid),
   );
+
+  useEffect(() => {
+    if (originData) {
+      setDiaryData({
+        ...diaryData,
+        title: originData.title,
+        content: originData.content,
+        date: originData.date,
+        tags: originData.tags,
+      });
+      titleRef.current && (titleRef.current.value = originData.title);
+      contentRef.current && (contentRef.current.value = originData.content);
+    }
+  }, [originData]);
 
   if (isLoading)
     return (

--- a/FE/src/pages/StarPage.js
+++ b/FE/src/pages/StarPage.js
@@ -36,6 +36,7 @@ function StarPage() {
             enableDamping={false}
             enableZoom={false}
             target={[0, 0, 0]}
+            rotateSpeed={-0.4}
           />
           <StarView />
         </Canvas>
@@ -169,8 +170,10 @@ function StarView() {
 
   const material = new THREE.ShaderMaterial({
     uniforms: {
-      color1: { value: new THREE.Color("#656990") },
-      color2: { value: new THREE.Color("#182683") },
+      // color1: { value: new THREE.Color("#656990") },
+      // color2: { value: new THREE.Color("#182683") },
+      color1: { value: new THREE.Color("#454980") },
+      color2: { value: new THREE.Color("#182663") },
       gradientStart: { value: 0.001 },
     },
     vertexShader: `


### PR DESCRIPTION
## 요약

- 일기 수정시 에러 수정
- 3D 뷰 로직 및 색상 일부 변경

## 변경 사항

- titleRef, contentRef의 current가 null일 때 값을 할당하는 경우가 있어, useEffect에 originData가 있을 때 넣게 함으로서 이슈 해결. 
- 3D view의 rotatespeed값을 음수값을 주어 직관적으로 회전하고자 하는 방향과 일치하도록 수정
- 밤하늘의 긍정적 별(파란색)이 비교적으로 잘 보이지 않아 밤하늘 색을 약간 더 어둡게 변경

## 참고 사항

- 기존 밤하늘 색이 더 나을 경우 롤백하기 위해 주석으로 기록해두었습니다.

