### PR TITLE
[Hotfix] 별자리선이 연결된 일기 삭제 시 별자리선도 함께 삭제

### DIFF
--- a/BE/src/diaries/diaries.module.ts
+++ b/BE/src/diaries/diaries.module.ts
@@ -10,10 +10,11 @@ import { ShapesModule } from "src/shapes/shapes.module";
 import { ShapesRepository } from "src/shapes/shapes.repository";
 import { TagsRepository } from "src/tags/tags.repository";
 import { HttpModule } from "@nestjs/axios";
+import { Line } from "src/lines/lines.entity";
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Diary]),
+    TypeOrmModule.forFeature([Diary, Line]),
     AuthModule,
     TagsModule,
     ShapesModule,

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -1,4 +1,5 @@
 import { User } from "src/auth/users.entity";
+import { Line } from "src/lines/lines.entity";
 import {
   CreateDiaryDto,
   DeleteDiaryDto,
@@ -98,7 +99,15 @@ export class DiariesRepository {
 
   async deleteDiary(deleteDiaryDto: DeleteDiaryDto): Promise<void> {
     const { uuid } = deleteDiaryDto;
-    const diary = await this.getDiaryByUuid(uuid);
+    const diary: Diary = await this.getDiaryByUuid(uuid);
+
+    const lines = await Line.find({
+      where: [
+        { firstDiary: { id: diary.id } },
+        { secondDiary: { id: diary.id } },
+      ],
+    });
+    await Line.softRemove(lines);
 
     await Diary.softRemove(diary);
   }


### PR DESCRIPTION
## 요약

- 일기를 삭제할 경우 해당 일기와 연결된 별자리선을 모두 찾아 soft remove 실행

## 변경 사항

### 일기를 삭제할 경우 해당 일기와 연결된 별자리선을 모두 찾아 soft remove 실행

- `onDelete` 옵션은 현재 soft remove를 하고 있어 제대로 동작하지 않음

>  https://yescoding.tech/backend/type-orm-soft-delete-cascade_en
- 원래 위 링크처럼 `cascade: ['soft-remove']` 옵션을 통해 삭제를 시도하였으나 ManyToOne(Line Entity)에 추가할 경우 라인이 삭제될 때 일기가 삭제됨
- Diary 엔티티에서 Line 엔티티로의 OneToMany 관계를 정의하고, 이 관계에 `cascade: ['soft-remove']` 옵션을 지정해보았으나 동작하지 않음
- Line 엔티티가 두 개의 Diary 엔티티를 참조하고 있어 동작하지 않을수도 있다고 함
- 따라서 Diary가 삭제될 때 Line 엔티티에서 해당 Diary를 참조하는 모든 레코드를 찾아서 soft delete하는 로직을 추가

## 참고 사항

- 현재 일기 삭제 후 새로고침 전까지 화면에 별자리선이 남아있게되어서 FE에 처리 필요
- 태그도 ManyToMany라 직접 삭제를 구현해야 할 것 같아 현재는 추가하지 않음

## 이슈 번호

- #178
