### PR TITLE
[Fix] 일기 생성, 수정 시 Content 관련 오류 수정

### DIFF
--- a/BE/src/diaries/diaries.service.ts
+++ b/BE/src/diaries/diaries.service.ts
@@ -28,11 +28,11 @@ export class DiariesService {
 
   async writeDiary(createDiaryDto: CreateDiaryDto, user: User): Promise<Diary> {
     const { content, shapeUuid, tags } = createDiaryDto;
+    const trimContent = content.trim();
     const shape = await this.shapesRepository.getShapeByUuid(shapeUuid);
-    const encryptedContent = await this.getEncryptedContent(content);
+    const encryptedContent = await this.getEncryptedContent(trimContent);
     const tagEntities = await this.getTags(tags);
-    const sentimentResult: SentimentDto = await this.getSentiment(content);
-
+    const sentimentResult: SentimentDto = await this.getSentiment(trimContent);
     const diary = await this.diariesRepository.createDiary(
       createDiaryDto,
       encryptedContent,
@@ -76,10 +76,11 @@ export class DiariesService {
     user: User,
   ): Promise<Diary> {
     const { content, shapeUuid, tags } = updateDiaryDto;
+    const trimContent = content.trim();
     const shape = await this.shapesRepository.getShapeByUuid(shapeUuid);
-    const encryptedContent = await this.getEncryptedContent(content);
+    const encryptedContent = await this.getEncryptedContent(trimContent);
     const tagEntities = await this.getTags(tags);
-    const sentimentResult = await this.getSentiment(content);
+    const sentimentResult = await this.getSentiment(trimContent);
 
     return this.diariesRepository.updateDiary(
       updateDiaryDto,


### PR DESCRIPTION
## 요약

- 일기의 content에서 앞 뒤 공백을 제거

## 변경 사항

### 일기의 content에서 앞 뒤 공백을 제거
- trim 메서드를 통해 일기의 content에서 앞 뒤 공백을 제거함
- 공백은 줄바꿈, 탭, 공백을 의미함

## 참고 사항

- 없음

## 이슈 번호

close #202 
