### PR TITLE
[Feat] 네이버 로그인

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -31,6 +31,7 @@
         "mysql2": "^3.6.3",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
+        "passport-naver-v2": "^2.0.8",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17"
@@ -3046,6 +3047,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
@@ -7211,6 +7220,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7463,6 +7477,33 @@
       "dependencies": {
         "jsonwebtoken": "^9.0.0",
         "passport-strategy": "^1.0.0"
+      }
+    },
+    "node_modules/passport-naver-v2": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/passport-naver-v2/-/passport-naver-v2-2.0.8.tgz",
+      "integrity": "sha512-CA0u+aA4K4Zf5e3dSd47agOS69ULOdBGei7CZY2BN1cEbLnhnc6OalFPvnXLuEKT8I4IuGwvh3EBZCST2FoI+A==",
+      "dependencies": {
+        "passport-oauth2": "^1.5.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.7.0.tgz",
+      "integrity": "sha512-j2gf34szdTF2Onw3+76alNnaAExlUmHvkc7cL+cmaS5NzHzDP/BvFHJruueQ9XAeNOdpI+CH+PWid8RA7KCwAQ==",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-strategy": {
@@ -9407,6 +9448,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/BE/package.json
+++ b/BE/package.json
@@ -43,6 +43,7 @@
     "mysql2": "^3.6.3",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
+    "passport-naver-v2": "^2.0.8",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17"

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -6,7 +6,6 @@ import {
   Post,
   Req,
   UseGuards,
-  Redirect,
 } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { AuthCredentialsDto } from "./dto/auth-credential.dto";

--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -1,10 +1,12 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   Post,
   Req,
   UseGuards,
+  Redirect,
 } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import { AuthCredentialsDto } from "./dto/auth-credential.dto";
@@ -16,12 +18,22 @@ import {
 import { CreateUserDto } from "./dto/users.dto";
 import { User } from "./users.entity";
 import { GetUser } from "./get-user.decorator";
-import { JwtAuthGuard } from "./guard/auth.jwt-guard";
 import { Request } from "express";
+import { AuthGuard } from "@nestjs/passport";
 
 @Controller("auth")
 export class AuthController {
   constructor(private authService: AuthService) {}
+
+  @Get("/naver/callback")
+  @UseGuards(AuthGuard("naver"))
+  @HttpCode(201)
+  async naverSignIn(
+    @GetUser() user: User,
+    @Req() request: Request,
+  ): Promise<AccessTokenDto> {
+    return await this.authService.naverSignIn(user, request);
+  }
 
   @Post("/signup")
   @HttpCode(204)

--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -4,12 +4,13 @@ import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
-import { JwtStrategy } from "./jwt.strategy";
+import { JwtStrategy } from "./strategies/jwt.strategy";
 import { PrivateDiaryGuard } from "./guard/auth.diary-guard";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "./users.entity";
 import { UsersRepository } from "./users.repository";
 import { DiariesRepository } from "src/diaries/diaries.repository";
+import { NaverOAuthStrategy } from "./strategies/naver.strategy";
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { DiariesRepository } from "src/diaries/diaries.repository";
     UsersRepository,
     PrivateDiaryGuard,
     DiariesRepository,
+    NaverOAuthStrategy,
   ],
   exports: [PassportModule, UsersRepository],
 })

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -9,7 +9,7 @@ import { User } from "./users.entity";
 import { Redis } from "ioredis";
 import { InjectRedis } from "@liaoliaots/nestjs-redis";
 import { Request } from "express";
-import * as jwt from "jsonwebtoken";
+import { providerEnum } from "src/utils/enum";
 
 @Injectable()
 export class AuthService {
@@ -89,7 +89,11 @@ export class AuthService {
   }
 
   async naverSignIn(user: User, request: Request): Promise<AccessTokenDto> {
-    if (!(await User.findOne({ where: { userId: user.userId } }))) {
+    if (
+      !(await User.findOne({
+        where: { userId: user.userId, provider: providerEnum.NAVER },
+      }))
+    ) {
       await user.save();
     }
     const userId = user.userId;

--- a/BE/src/auth/strategies/jwt.strategy.ts
+++ b/BE/src/auth/strategies/jwt.strategy.ts
@@ -24,7 +24,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any): Promise<User> {
-    console.log("jwtStrategy");
     if (!payload) {
       throw new UnauthorizedException();
     }

--- a/BE/src/auth/strategies/jwt.strategy.ts
+++ b/BE/src/auth/strategies/jwt.strategy.ts
@@ -24,6 +24,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any): Promise<User> {
+    console.log("jwtStrategy");
     if (!payload) {
       throw new UnauthorizedException();
     }

--- a/BE/src/auth/strategies/naver.strategy.ts
+++ b/BE/src/auth/strategies/naver.strategy.ts
@@ -3,6 +3,7 @@ import { PassportStrategy } from "@nestjs/passport";
 import { Request } from "express";
 import { Profile, Strategy } from "passport-naver-v2";
 import { User } from "../users.entity";
+import { providerEnum } from "src/utils/enum";
 
 @Injectable()
 export class NaverOAuthStrategy extends PassportStrategy(Strategy, "naver") {
@@ -10,7 +11,7 @@ export class NaverOAuthStrategy extends PassportStrategy(Strategy, "naver") {
     super({
       clientID: process.env.NAVER_CLIENT_ID,
       clientSecret: process.env.NAVER_CLIENT_PASS,
-      callbackURL: "http://localhost:3005/auth/naver/callback",
+      callbackURL: `${process.env.BACKEND_URL}/auth/naver/callback`,
       passReqToCallback: true,
     });
   }
@@ -25,10 +26,11 @@ export class NaverOAuthStrategy extends PassportStrategy(Strategy, "naver") {
       const { email, id, nickname } = profile;
       const user = new User();
 
-      user.email = email + "*naver";
+      user.email = email;
       user.userId = id + "*naver";
       user.nickname = nickname;
       user.password = "naver";
+      user.provider = providerEnum.NAVER;
 
       return user;
     } catch (error) {

--- a/BE/src/auth/strategies/naver.strategy.ts
+++ b/BE/src/auth/strategies/naver.strategy.ts
@@ -1,0 +1,38 @@
+import { Injectable, BadRequestException } from "@nestjs/common";
+import { PassportStrategy } from "@nestjs/passport";
+import { Request } from "express";
+import { Profile, Strategy } from "passport-naver-v2";
+import { User } from "../users.entity";
+
+@Injectable()
+export class NaverOAuthStrategy extends PassportStrategy(Strategy, "naver") {
+  constructor() {
+    super({
+      clientID: process.env.NAVER_CLIENT_ID,
+      clientSecret: process.env.NAVER_CLIENT_PASS,
+      callbackURL: "http://localhost:3005/auth/naver/callback",
+      passReqToCallback: true,
+    });
+  }
+
+  async validate(
+    req: Request,
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+  ): Promise<User> {
+    try {
+      const { email, id, nickname } = profile;
+      const user = new User();
+
+      user.email = email + "*naver";
+      user.userId = id + "*naver";
+      user.nickname = nickname;
+      user.password = "naver";
+
+      return user;
+    } catch (error) {
+      throw new BadRequestException("네이버 로그인 중 오류가 발생했습니다.");
+    }
+  }
+}

--- a/BE/src/auth/strategies/naver.strategy.ts
+++ b/BE/src/auth/strategies/naver.strategy.ts
@@ -1,6 +1,5 @@
 import { Injectable, BadRequestException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
-import { Request } from "express";
 import { Profile, Strategy } from "passport-naver-v2";
 import { User } from "../users.entity";
 import { providerEnum } from "src/utils/enum";
@@ -12,12 +11,10 @@ export class NaverOAuthStrategy extends PassportStrategy(Strategy, "naver") {
       clientID: process.env.NAVER_CLIENT_ID,
       clientSecret: process.env.NAVER_CLIENT_PASS,
       callbackURL: `${process.env.BACKEND_URL}/auth/naver/callback`,
-      passReqToCallback: true,
     });
   }
 
   async validate(
-    req: Request,
     accessToken: string,
     refreshToken: string,
     profile: Profile,
@@ -34,7 +31,9 @@ export class NaverOAuthStrategy extends PassportStrategy(Strategy, "naver") {
 
       return user;
     } catch (error) {
-      throw new BadRequestException("네이버 로그인 중 오류가 발생했습니다.");
+      throw new BadRequestException(
+        `네이버 로그인 중 오류가 발생했습니다 : ${error.message}`,
+      );
     }
   }
 }

--- a/BE/src/auth/users.entity.ts
+++ b/BE/src/auth/users.entity.ts
@@ -9,13 +9,12 @@ import {
   OneToMany,
   Unique,
 } from "typeorm";
-import { premiumStatus } from "src/utils/enum";
+import { premiumStatus, providerEnum } from "src/utils/enum";
 import { Diary } from "../diaries/diaries.entity";
 import { Shape } from "src/shapes/shapes.entity";
 
 @Entity()
 @Unique(["userId"])
-@Unique(["email"])
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -46,6 +45,9 @@ export class User extends BaseEntity {
 
   @DeleteDateColumn({ type: "datetime" })
   deletedDate: Date;
+
+  @Column({ type: "enum", enum: providerEnum, default: providerEnum.BYEOLSOOP })
+  provider: providerEnum;
 
   @OneToMany(() => Diary, (diary) => diary.user)
   diaries: Diary[];

--- a/BE/src/auth/users.entity.ts
+++ b/BE/src/auth/users.entity.ts
@@ -20,7 +20,7 @@ export class User extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ length: 20 })
+  @Column({ length: 60 })
   userId: string;
 
   @Column()

--- a/BE/src/utils/enum.ts
+++ b/BE/src/utils/enum.ts
@@ -9,3 +9,9 @@ export enum sentimentStatus {
   NEUTRAL = "neutral",
   ERROR = "error",
 }
+
+export enum providerEnum {
+  BYEOLSOOP = "byeolsoop",
+  NAVER = "naver",
+  KAKAO = "kakao",
+}


### PR DESCRIPTION
## 요약

- 네이버 로그인 전략 구현
- 네이버 OAuth 콜백 API 구현

## 변경 사항

### 네이버 로그인 전략 구현
- passport-naver-v2 라이브러리를 설치해서 NaverOAuthStrategy 구현
  - 생성자를 통해 인증 서버에 액세스 토큰, 리프레시 토큰, 프로필 정보를 요청한다.
  - NaverOAuthStrategy의 validate에서 네이버 아이디 프로필의 정보를 가공해서 User 객체에 저장함

### 네이버 OAuth 콜백 API 구현
- /auth/naver/callback GET 요청 시 NaverOAuthStrategy를 통해 프로필 정보가 가공된 User 객체를 받음
- 해당 User 객체가 존재하지 않는 경우 새로 데이터베이스에 저장함
- 기존 로그인 과정과 동일하게 액세스 토큰을 발급하고 리프레시 토큰을 Redis에 저장한 후 액세스 토큰을 201 Created와 함께 응답함

## 참고 사항

- 현재는 네이버 로그인으로 byeolsoop08 아이디만 로그인 가능해요. 추가로 네이버 아이디 로그인 해보고 싶으시면 저한테 말씀해주시면 아이디 등록해서 로그인할 수 있게 만들겠습니다.

## 이슈 번호

close #200 
