### PR TITLE
[Chore] passport-naver 버전 낮추기

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -31,7 +31,8 @@
         "mysql2": "^3.6.3",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
-        "passport-naver-v2": "^2.0.8",
+        "passport-kakao": "^1.0.1",
+        "passport-naver": "^1.0.6",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17"
@@ -7479,12 +7480,64 @@
         "passport-strategy": "^1.0.0"
       }
     },
-    "node_modules/passport-naver-v2": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/passport-naver-v2/-/passport-naver-v2-2.0.8.tgz",
-      "integrity": "sha512-CA0u+aA4K4Zf5e3dSd47agOS69ULOdBGei7CZY2BN1cEbLnhnc6OalFPvnXLuEKT8I4IuGwvh3EBZCST2FoI+A==",
+    "node_modules/passport-kakao": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-kakao/-/passport-kakao-1.0.1.tgz",
+      "integrity": "sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==",
       "dependencies": {
-        "passport-oauth2": "^1.5.0"
+        "passport-oauth2": "~1.1.2",
+        "pkginfo": "~0.3.0"
+      }
+    },
+    "node_modules/passport-kakao/node_modules/passport-oauth2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz",
+      "integrity": "sha512-wpsGtJDHHQUjyc9WcV9FFB0bphFExpmKtzkQrxpH1vnSr6RcWa3ZEGHx/zGKAh2PN7Po9TKYB1fJeOiIBspNPA==",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-naver": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/passport-naver/-/passport-naver-1.0.6.tgz",
+      "integrity": "sha512-5XEbJesiPVshwE0cTDvbbJrOiYSJ9VFRJTctqiZL1Xip6qOi9n7d49UesOqavLT+Ry8C7aw3zdzbmWosqHcQ/Q==",
+      "dependencies": {
+        "passport-oauth": "^1.0.0",
+        "underscore": "^1.8.3"
+      }
+    },
+    "node_modules/passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==",
+      "dependencies": {
+        "passport-oauth1": "1.x.x",
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth1": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.3.0.tgz",
+      "integrity": "sha512-8T/nX4gwKTw0PjxP1xfD0QhrydQNakzeOpZ6M5Uqdgz9/a/Ag62RmJxnZQ4LkbdXGrRehQHIAHNAu11rCP46Sw==",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-oauth2": {
@@ -7680,6 +7733,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/pluralize": {
@@ -9453,6 +9514,11 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
+    "node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/BE/package.json
+++ b/BE/package.json
@@ -43,7 +43,8 @@
     "mysql2": "^3.6.3",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
-    "passport-naver-v2": "^2.0.8",
+    "passport-kakao": "^1.0.1",
+    "passport-naver": "^1.0.6",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17"

--- a/BE/src/auth/strategies/naver.strategy.ts
+++ b/BE/src/auth/strategies/naver.strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable, BadRequestException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
-import { Profile, Strategy } from "passport-naver-v2";
+import { Profile, Strategy } from "passport-naver";
 import { User } from "../users.entity";
 import { providerEnum } from "src/utils/enum";
 


### PR DESCRIPTION
- passport-kakao와의 충돌을 피하기 위해 passport-naver의 버전을 구버전으로 사용

> PR 올리기 전/후 아래 내용을 확인하고 지우세요!

- PR 템플릿 제목이 [기능명] PR 제목의 형식을 갖추고 있는지 확인
- 브랜치 이름이 {기능명}/{issue-number}-{feature-name}의 형식을 갖추고 있는지 확인
- PR 후 conflict가 나지 않는지 확인 (충돌 시 해결 필수)
- merge 이후 브랜치에 해당하는 issue가 closed 되었는지 확인

## 요약

- passport-naver 버전 낮추기

## 변경 사항

### passport-naver 버전 낮추기
- passport-kakao와의 충돌을 피하기 위해 최신의 passport-naver-v2 대신 passport-naver를 사용 


## 참고 사항

- passport-oauth 라이브러리가 passport-kakao에서는 1.1.2 이하를, passport-naver-v2에서는 1.5.0 이상을 원했기 때문에 passport-naver 쪽을 다운그레이드 했습니다.

## 이슈 번호

없음
