### PR TITLE
[Feat] 유료 디자인 구매 API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -10,8 +10,9 @@ import { ShapesRepository } from "./shapes/shapes.repository";
 import { UsersRepository } from "./auth/users.repository";
 import { typeORMTestConfig } from "./configs/typeorm.test.config";
 import { RedisModule } from "@liaoliaots/nestjs-redis";
-import { StatModule } from './stat/stat.module';
-import { LinesModule } from './lines/lines.module';
+import { StatModule } from "./stat/stat.module";
+import { LinesModule } from "./lines/lines.module";
+import { PurchaseModule } from "./purchase/purchase.module";
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { LinesModule } from './lines/lines.module';
     ShapesModule,
     StatModule,
     LinesModule,
+    PurchaseModule,
   ],
   providers: [ShapesRepository, UsersRepository],
 })

--- a/BE/src/auth/users.entity.ts
+++ b/BE/src/auth/users.entity.ts
@@ -12,6 +12,7 @@ import {
 import { premiumStatus, providerEnum } from "src/utils/enum";
 import { Diary } from "../diaries/diaries.entity";
 import { Shape } from "src/shapes/shapes.entity";
+import { Purchase } from "src/purchase/purchase.entity";
 
 @Entity()
 @Unique(["userId"])
@@ -54,4 +55,7 @@ export class User extends BaseEntity {
 
   @OneToMany(() => Shape, (shape) => shape.user)
   shapes: Diary[];
+
+  @OneToMany(() => Purchase, (purchase) => purchase.user)
+  purchases: Purchase[];
 }

--- a/BE/src/purchase/dto/purchase.design.dto.ts
+++ b/BE/src/purchase/dto/purchase.design.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty } from "class-validator";
+
+export class PurchaseDesignDto {
+  @IsNotEmpty({ message: "구매 항목 종류는 비어있지 않아야 합니다." })
+  domain: string;
+
+  @IsNotEmpty({ message: "디자인은 비어있지 않아야 합니다." })
+  design: string;
+}

--- a/BE/src/purchase/purchase.controller.ts
+++ b/BE/src/purchase/purchase.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, UseGuards, Body, HttpCode } from "@nestjs/common";
+import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
+import { PurchaseService } from "./purchase.service";
+import { PurchaseDesignDto } from "./dto/purchase.design.dto";
+import { GetUser } from "src/auth/get-user.decorator";
+import { User } from "src/auth/users.entity";
+
+@Controller("purchase")
+@UseGuards(JwtAuthGuard)
+export class PurchaseController {
+  constructor(private purchaseService: PurchaseService) {}
+
+  @Post("/design")
+  @HttpCode(204)
+  async purchaseDesign(
+    @GetUser() user: User,
+    @Body() purchaseDesignDto: PurchaseDesignDto,
+  ): Promise<void> {
+    await this.purchaseService.purchaseDesign(user, purchaseDesignDto);
+  }
+}

--- a/BE/src/purchase/purchase.entity.ts
+++ b/BE/src/purchase/purchase.entity.ts
@@ -1,0 +1,33 @@
+import { User } from "src/auth/users.entity";
+import { designEnum, domainEnum } from "src/utils/enum";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  BaseEntity,
+  Column,
+  ManyToOne,
+} from "typeorm";
+
+@Entity()
+export class Purchase extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({
+    type: "enum",
+    enum: domainEnum,
+  })
+  domain: domainEnum;
+
+  @Column({
+    type: "enum",
+    enum: designEnum,
+  })
+  design: designEnum;
+
+  @ManyToOne(() => User, (user) => user.userId, {
+    nullable: false,
+    eager: true,
+  })
+  user: User;
+}

--- a/BE/src/purchase/purchase.module.ts
+++ b/BE/src/purchase/purchase.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Purchase } from "./purchase.entity";
+import { PurchaseController } from "./purchase.controller";
+import { PurchaseService } from "./purchase.service";
+import { PurchaseRepository } from "./purchase.repository";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Purchase])],
+  controllers: [PurchaseController],
+  providers: [PurchaseService, PurchaseRepository],
+  exports: [PurchaseRepository],
+})
+export class PurchaseModule {}

--- a/BE/src/purchase/purchase.repository.ts
+++ b/BE/src/purchase/purchase.repository.ts
@@ -1,0 +1,20 @@
+import { Purchase } from "./purchase.entity";
+import { PurchaseDesignDto } from "./dto/purchase.design.dto";
+import { User } from "src/auth/users.entity";
+import { designEnum, domainEnum } from "src/utils/enum";
+
+export class PurchaseRepository {
+  async purchaseDesign(
+    user: User,
+    domain: domainEnum,
+    design: designEnum,
+  ): Promise<void> {
+    const purchase = await Purchase.create();
+
+    purchase.domain = domain;
+    purchase.design = design;
+    purchase.user = user;
+
+    purchase.save();
+  }
+}

--- a/BE/src/purchase/purchase.service.ts
+++ b/BE/src/purchase/purchase.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, BadRequestException } from "@nestjs/common";
+import { PurchaseDesignDto } from "./dto/purchase.design.dto";
+import { User } from "src/auth/users.entity";
+import { PurchaseRepository } from "./purchase.repository";
+import { Purchase } from "./purchase.entity";
+import { designEnum, domainEnum } from "src/utils/enum";
+
+@Injectable()
+export class PurchaseService {
+  constructor(private purchaseRepository: PurchaseRepository) {}
+
+  async purchaseDesign(
+    user: User,
+    purchaseDesignDto: PurchaseDesignDto,
+  ): Promise<void> {
+    const domain = domainEnum[purchaseDesignDto.domain];
+    const design = designEnum[purchaseDesignDto.design];
+
+    if (user.credit < 500) {
+      throw new BadRequestException(
+        `보유한 별가루가 부족합니다. 현재 ${user.credit} 별가루`,
+      );
+    }
+
+    if (
+      Purchase.findOne({
+        where: {
+          user: { userId: user.userId },
+          domain: domain,
+          design: design,
+        },
+      })
+    ) {
+      throw new BadRequestException(`이미 구매한 디자인입니다.`);
+    }
+
+    user.credit -= 500;
+    user.save();
+
+    await this.purchaseRepository.purchaseDesign(user, domain, design);
+  }
+}

--- a/BE/src/utils/enum.ts
+++ b/BE/src/utils/enum.ts
@@ -15,3 +15,13 @@ export enum providerEnum {
   NAVER = "naver",
   KAKAO = "kakao",
 }
+
+export enum domainEnum {
+  GROUND = "ground",
+  SKY = "sky",
+}
+
+export enum designEnum {
+  GROUND_GREEN = "#254117",
+  GROUND_MOCHA = "#493D26",
+}


### PR DESCRIPTION
## 요약

- Purchase 기능 초기 작업
- 유료 디자인 구매 API 구현

## 변경 사항

### Purchase 기능 초기 작업
- Purchase 엔티티를 작성하여 MySQL DB에 purchase 테이블 생성
  - Purchase 엔티티의 속성을 위한 domainEnum, designEnum 작성. 
- Purchase 도메인을 위한 PurchaseModule을 작성하고 AppModule에 Import함

### 유료 디자인 구매 API 구현
- /purchase/design POST 요청에 대한 유료 디자인 구매 API를 구현
- 현재 사용자가 보유한 별가루가 부족하거나, 이미 해당 디자인을 구매한 경우 400 Bad Request 응답

## 참고 사항

- 추후 도메인이나 디자인이 추가될 경우 Enum에 추가하도록 확장성 고려함
- 테스트 코드는 현재 PR이 머지되면 네이버 로그인 API와 동시에 작성 예정

## 이슈 번호

#205 