### PR TITLE
[Feat] 유료 디자인 구매 목록 API 구현

### DIFF
--- a/BE/src/purchase/dto/purchase.design.dto.ts
+++ b/BE/src/purchase/dto/purchase.design.dto.ts
@@ -7,3 +7,7 @@ export class PurchaseDesignDto {
   @IsNotEmpty({ message: "디자인은 비어있지 않아야 합니다." })
   design: string;
 }
+
+export class PurchaseListDto {
+  [domain: string]: { design: string[] };
+}

--- a/BE/src/purchase/purchase.controller.ts
+++ b/BE/src/purchase/purchase.controller.ts
@@ -1,7 +1,14 @@
-import { Controller, Post, UseGuards, Body, HttpCode } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Post,
+  UseGuards,
+  Body,
+  HttpCode,
+} from "@nestjs/common";
 import { JwtAuthGuard } from "src/auth/guard/auth.jwt-guard";
 import { PurchaseService } from "./purchase.service";
-import { PurchaseDesignDto } from "./dto/purchase.design.dto";
+import { PurchaseDesignDto, PurchaseListDto } from "./dto/purchase.design.dto";
 import { GetUser } from "src/auth/get-user.decorator";
 import { User } from "src/auth/users.entity";
 
@@ -17,5 +24,11 @@ export class PurchaseController {
     @Body() purchaseDesignDto: PurchaseDesignDto,
   ): Promise<void> {
     await this.purchaseService.purchaseDesign(user, purchaseDesignDto);
+  }
+
+  @Get("/design")
+  @HttpCode(200)
+  async getDesignPurchaseList(@GetUser() user: User): Promise<PurchaseListDto> {
+    return await this.purchaseService.getDesignPurchaseList(user);
   }
 }

--- a/BE/src/purchase/purchase.repository.ts
+++ b/BE/src/purchase/purchase.repository.ts
@@ -17,4 +17,8 @@ export class PurchaseRepository {
 
     purchase.save();
   }
+
+  async getDesignPurchaseList(user: User) {
+    return Purchase.find({ where: { user: { userId: user.userId } } });
+  }
 }

--- a/BE/src/purchase/purchase.service.ts
+++ b/BE/src/purchase/purchase.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, BadRequestException } from "@nestjs/common";
-import { PurchaseDesignDto } from "./dto/purchase.design.dto";
+import { PurchaseDesignDto, PurchaseListDto } from "./dto/purchase.design.dto";
 import { User } from "src/auth/users.entity";
 import { PurchaseRepository } from "./purchase.repository";
 import { Purchase } from "./purchase.entity";
@@ -23,7 +23,7 @@ export class PurchaseService {
     }
 
     if (
-      Purchase.findOne({
+      await Purchase.findOne({
         where: {
           user: { userId: user.userId },
           domain: domain,
@@ -38,5 +38,26 @@ export class PurchaseService {
     user.save();
 
     await this.purchaseRepository.purchaseDesign(user, domain, design);
+  }
+
+  async getDesignPurchaseList(user: User): Promise<PurchaseListDto> {
+    const purchaseList =
+      await this.purchaseRepository.getDesignPurchaseList(user);
+
+    const groundPurchase = [];
+    const skyPurchase = [];
+    await purchaseList.forEach((purchase) => {
+      if (purchase.domain === "ground") {
+        groundPurchase.push(purchase.design);
+      }
+      if (purchase.domain === "sky") {
+        skyPurchase.push(purchase.design);
+      }
+    });
+
+    const result = {};
+    result["ground"] = groundPurchase;
+    result["sky"] = skyPurchase;
+    return result;
   }
 }

--- a/BE/test/e2e/purchase.design-list.e2e-spec.ts
+++ b/BE/test/e2e/purchase.design-list.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { ValidationPipe } from "@nestjs/common";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { RedisModule } from "@liaoliaots/nestjs-redis";
+import { clearUserDb } from "src/utils/clearDb";
+import { UsersRepository } from "src/auth/users.repository";
+import { AuthModule } from "src/auth/auth.module";
+import { PurchaseModule } from "src/purchase/purchase.module";
+import { User } from "src/auth/users.entity";
+
+describe("[디자인 구매 내역 조회] /purchase/design GET e2e 테스트", () => {
+  let app: INestApplication;
+  let accessToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot(typeORMTestConfig),
+        RedisModule.forRoot({
+          readyLog: true,
+          config: {
+            host: "223.130.129.145",
+            port: 6379,
+          },
+        }),
+        PurchaseModule,
+        AuthModule,
+      ],
+      providers: [UsersRepository],
+    }).compile();
+
+    let usersRepository = moduleFixture.get<UsersRepository>(UsersRepository);
+
+    await clearUserDb(moduleFixture, usersRepository);
+
+    app = moduleFixture.createNestApplication();
+    app.enableCors();
+    app.useGlobalPipes(new ValidationPipe());
+
+    await app.init();
+
+    const signInPost = await request(app.getHttpServer())
+      .post("/auth/signin")
+      .send({
+        userId: "commonUser",
+        password: process.env.COMMON_USER_PASS,
+      });
+
+    accessToken = signInPost.body.accessToken;
+
+    // 1000 별가루 충전
+    const user = await User.findOne({ where: { userId: "commonUser" } });
+    user.credit = 1000;
+    await user.save();
+
+    // 디자인 구매
+    await request(app.getHttpServer())
+      .post("/purchase/design")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        domain: "GROUND",
+        design: "GROUND_GREEN",
+      });
+
+    await request(app.getHttpServer())
+      .post("/purchase/design")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({
+        domain: "GROUND",
+        design: "GROUND_MOCHA",
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("정상 요청 시 200 OK 응답", async () => {
+    const getResponse = await request(app.getHttpServer())
+      .get("/purchase/design")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(getResponse.body).toStrictEqual({
+      ground: ["#254117", "#493D26"],
+      sky: [],
+    });
+  });
+
+  it("유효하지 않은 토큰 요청 시 401 Unauthorized 응답", async () => {
+    const getResponse = await request(app.getHttpServer())
+      .get("/purchase/design")
+      .expect(401);
+  });
+});

--- a/BE/test/int/purchase.repository.int-spec.ts
+++ b/BE/test/int/purchase.repository.int-spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { User } from "src/auth/users.entity";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { Purchase } from "src/purchase/purchase.entity";
+import { PurchaseRepository } from "src/purchase/purchase.repository";
+
+describe("PurchaseRepository 통합 테스트", () => {
+  let purchaseRepository: PurchaseRepository;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig)],
+      providers: [PurchaseRepository],
+    }).compile();
+
+    purchaseRepository = module.get<PurchaseRepository>(PurchaseRepository);
+  });
+
+  afterEach(async () => {
+    await jest.restoreAllMocks();
+  });
+
+  describe("getDesignPurchaseList 메서드", () => {
+    it("메서드 정상 요청", async () => {
+      const user = await User.findOne({ where: { userId: "commonUser" } });
+
+      const purchaseList = await Purchase.find({
+        where: { user: { userId: user.userId } },
+      });
+      const result = await purchaseRepository.getDesignPurchaseList(user);
+
+      expect(result).toStrictEqual(purchaseList);
+    });
+  });
+});

--- a/BE/test/int/purchase.service.int-spec.ts
+++ b/BE/test/int/purchase.service.int-spec.ts
@@ -1,0 +1,37 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { User } from "src/auth/users.entity";
+import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { PurchaseRepository } from "src/purchase/purchase.repository";
+import { PurchaseService } from "src/purchase/purchase.service";
+
+describe("PurchaseService 통합 테스트", () => {
+  let purchaseService: PurchaseService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TypeOrmModule.forRoot(typeORMTestConfig)],
+      providers: [PurchaseService, PurchaseRepository],
+    }).compile();
+
+    purchaseService = module.get<PurchaseService>(PurchaseService);
+  });
+
+  afterEach(async () => {
+    await jest.restoreAllMocks();
+  });
+
+  describe("getDesignPurchaseList 메서드", () => {
+    it("메서드 정상 요청", async () => {
+      const user = await User.findOne({ where: { userId: "commonUser" } });
+
+      // 테스트 DB 독립 시 수정 필요
+      const result = await purchaseService.getDesignPurchaseList(user);
+
+      expect(result).toStrictEqual({
+        ground: ["#254117", "#493D26"],
+        sky: [],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 요약

- 유료 디자인 구매 목록 API 구현
- 유료 디자인 구매 목록 API 테스트 코드 작성

## 변경 사항

### 유료 디자인 구매 목록 API 구현
- /purchase/design GET 요청 시 현재 사용자의 유료 디자인 구매 목록을 응답하는 API 구현

### 유료 디자인 구매 목록 API 테스트 코드 작성
- /purchase/design GET API에 대한 e2e 테스트 작성
- PurchaseService와 PurchaseRepository의 getDesignPurchaseList 메서드에 대한 통합 테스트 작성

## 참고 사항
- PurchaseService의 통합 테스트에서 유료 디자인 구매 데이터를 넣지 않고 진행함. 현재는 테스트 DB가 독립되어 있지 않기 떄문에 이렇게 구현해둠. 추후 테스트 DB 독립화 이후 일괄적으로 테스트 수정 예정

### 실행 결과
![image](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/03a83336-6950-42dd-bcca-eca2018c4a4a)



## 이슈 번호
close #211 
