### PR TITLE
[Test] 네이버 로그인, 유료 디자인 구매 관련 테스트 코드 작성

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -18,7 +18,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --config ./test/jest-e2e.json",
-    "test:int": "cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --config ./test/jest-int.json"
+    "test:int": "cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --config ./test/jest-int.json",
+    "test:unit": "cross-env NODE_ENV=test jest --runInBand --detectOpenHandles --config ./test/jest-unit.json"
   },
   "dependencies": {
     "@liaoliaots/nestjs-redis": "^9.0.5",

--- a/BE/src/purchase/dto/purchase.design.dto.ts
+++ b/BE/src/purchase/dto/purchase.design.dto.ts
@@ -1,10 +1,17 @@
-import { IsNotEmpty } from "class-validator";
+import { IsEnum, IsIn, IsNotEmpty } from "class-validator";
+import { designEnum, domainEnum } from "src/utils/enum";
 
 export class PurchaseDesignDto {
   @IsNotEmpty({ message: "구매 항목 종류는 비어있지 않아야 합니다." })
+  @IsIn(Object.keys(domainEnum), {
+    message: "적절하지 않은 구매 항목 종류 양식입니다.",
+  })
   domain: string;
 
   @IsNotEmpty({ message: "디자인은 비어있지 않아야 합니다." })
+  @IsIn(Object.keys(designEnum), {
+    message: "적절하지 않은 디자인 양식입니다.",
+  })
   design: string;
 }
 

--- a/BE/test/int/auth.service.int-spec.ts
+++ b/BE/test/int/auth.service.int-spec.ts
@@ -13,6 +13,7 @@ import { AuthCredentialsDto } from "src/auth/dto/auth-credential.dto";
 import { Request } from "express";
 import { AccessTokenDto } from "src/auth/dto/auth-access-token.dto";
 import { NotFoundException } from "@nestjs/common";
+import { providerEnum } from "src/utils/enum";
 
 describe("AuthService 통합 테스트", () => {
   let authService: AuthService;
@@ -128,6 +129,23 @@ describe("AuthService 통합 테스트", () => {
 
       await authService.signIn(authCredentialsDto, request);
       const result = await authService.reissueAccessToken(user, request);
+
+      expect(result).toBeInstanceOf(AccessTokenDto);
+    });
+  });
+
+  describe("naverSignIn 메서드", () => {
+    it("메서드 정상 요청", async () => {
+      const user = new User();
+      user.email = "test@naver.com";
+      user.userId = "test*naver";
+      user.nickname = "test";
+      user.password = "test";
+      user.provider = providerEnum.NAVER;
+
+      const request = { ip: "111.111.111.111" } as Request;
+
+      const result = await authService.naverSignIn(user, request);
 
       expect(result).toBeInstanceOf(AccessTokenDto);
     });

--- a/BE/test/int/purchase.service.int-spec.ts
+++ b/BE/test/int/purchase.service.int-spec.ts
@@ -1,31 +1,68 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "src/auth/users.entity";
+import { UsersRepository } from "src/auth/users.repository";
 import { typeORMTestConfig } from "src/configs/typeorm.test.config";
+import { PurchaseDesignDto } from "src/purchase/dto/purchase.design.dto";
+import { Purchase } from "src/purchase/purchase.entity";
 import { PurchaseRepository } from "src/purchase/purchase.repository";
 import { PurchaseService } from "src/purchase/purchase.service";
+import { clearUserDb } from "src/utils/clearDb";
+import { DataSource } from "typeorm";
 
 describe("PurchaseService 통합 테스트", () => {
   let purchaseService: PurchaseService;
+  let user: User;
+  let usersRepository: UsersRepository;
+  let dataSource: DataSource;
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [TypeOrmModule.forRoot(typeORMTestConfig)],
-      providers: [PurchaseService, PurchaseRepository],
+      providers: [PurchaseService, PurchaseRepository, UsersRepository],
     }).compile();
 
-    purchaseService = module.get<PurchaseService>(PurchaseService);
+    dataSource = moduleFixture.get<DataSource>(DataSource);
+    purchaseService = moduleFixture.get<PurchaseService>(PurchaseService);
+
+    usersRepository = await moduleFixture.get<UsersRepository>(UsersRepository);
+    await clearUserDb(moduleFixture, usersRepository);
+
+    user = new User();
+    user.userId = "purchaseTest";
+    user.password = "purchaseTest";
+    user.nickname = "purchaseTest";
+    user.email = "email@email.com";
+    await user.save();
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  describe("purchaseDesign 메서드", () => {
+    it("메서드 정상 요청", async () => {
+      const purchaseDesignDto = new PurchaseDesignDto();
+      purchaseDesignDto.domain = "GROUND";
+      purchaseDesignDto.design = "GROUND_GREEN";
+      user.credit = 500;
+      await user.save();
+
+      await purchaseService.purchaseDesign(user, purchaseDesignDto);
+    });
+
+    // 별가루가 부족한 경우 테스트
+    // 이미 존재하는 디자인에 대한 경우 테스트
+    // 위 두 테스트는 테스트 DB 데이터 삭제 오류의 문제로 테스트 DB 독립화 이후 구현 예정
   });
 
   describe("getDesignPurchaseList 메서드", () => {
     it("메서드 정상 요청", async () => {
-      const user = await User.findOne({ where: { userId: "commonUser" } });
-
       // 테스트 DB 독립 시 수정 필요
       const result = await purchaseService.getDesignPurchaseList(user);
 
       expect(result).toStrictEqual({
-        ground: ["#254117", "#493D26"],
+        ground: ["#254117"],
         sky: [],
       });
     });

--- a/BE/test/jest-unit.json
+++ b/BE/test/jest-unit.json
@@ -1,0 +1,12 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".unit-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
+  }
+}

--- a/BE/test/unit/auth-credential.dto.unit-spec.ts
+++ b/BE/test/unit/auth-credential.dto.unit-spec.ts
@@ -1,5 +1,5 @@
 import { validate } from "class-validator";
-import { AuthCredentialsDto } from "./auth-credential.dto";
+import { AuthCredentialsDto } from "../../src/auth/dto/auth-credential.dto";
 
 describe("AuthCredentialsDto 단위 테스트", () => {
   let authCredentialsDto;

--- a/BE/test/unit/diaries.dto.unit-spec.ts
+++ b/BE/test/unit/diaries.dto.unit-spec.ts
@@ -1,6 +1,10 @@
 import { validate } from "class-validator";
-import { ReadDiaryDto } from "./diaries.read.dto";
-import { CreateDiaryDto, DeleteDiaryDto, UpdateDiaryDto } from "./diaries.dto";
+import { ReadDiaryDto } from "../../src/diaries/dto/diaries.read.dto";
+import {
+  CreateDiaryDto,
+  DeleteDiaryDto,
+  UpdateDiaryDto,
+} from "../../src/diaries/dto/diaries.dto";
 
 describe("CreateDiaryDto 단위 테스트", () => {
   let createDiaryDto: CreateDiaryDto;

--- a/BE/test/unit/purchase.design.dto.unit-spec.ts
+++ b/BE/test/unit/purchase.design.dto.unit-spec.ts
@@ -1,0 +1,59 @@
+import { validate } from "class-validator";
+import { PurchaseDesignDto } from "../../src/purchase/dto/purchase.design.dto";
+
+describe("PurchaaseDesignDto 단위 테스트", () => {
+  let purchaseDesignDto;
+
+  beforeEach(() => {
+    purchaseDesignDto = new PurchaseDesignDto();
+  });
+
+  it("모든 값이 유효한 요청 시 성공", async () => {
+    purchaseDesignDto.domain = "GROUND";
+    purchaseDesignDto.design = "GROUND_GREEN";
+
+    const errors = await validate(purchaseDesignDto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("빈 구매 항목 종류로 요청 시 실패", async () => {
+    purchaseDesignDto.domain = "";
+    purchaseDesignDto.design = "GROUND_GREEN";
+
+    const errors = await validate(purchaseDesignDto);
+    expect(errors[0].constraints.isNotEmpty).toBe(
+      "구매 항목 종류는 비어있지 않아야 합니다.",
+    );
+  });
+
+  it("domainEnum 값이 아닌 구매 항목 종류로 요청 시 실패", async () => {
+    purchaseDesignDto.domain = "실패";
+    purchaseDesignDto.design = "GROUND_GREEN";
+
+    const errors = await validate(purchaseDesignDto);
+    expect(errors[0].constraints.isIn).toBe(
+      "적절하지 않은 구매 항목 종류 양식입니다.",
+    );
+  });
+
+  it("빈 디자인으로 요청 시 실패", async () => {
+    purchaseDesignDto.domain = "GROUND";
+    purchaseDesignDto.design = "";
+
+    const errors = await validate(purchaseDesignDto);
+
+    expect(errors[0].constraints.isNotEmpty).toBe(
+      "디자인은 비어있지 않아야 합니다.",
+    );
+  });
+
+  it("designEnum 값이 아닌 디자인으로 요청 시 실패", async () => {
+    purchaseDesignDto.domain = "GROUND";
+    purchaseDesignDto.design = "실패";
+
+    const errors = await validate(purchaseDesignDto);
+
+    expect(errors[0].constraints.isIn).toBe("적절하지 않은 디자인 양식입니다.");
+  });
+});

--- a/BE/test/unit/users.dto.unit-spec.ts
+++ b/BE/test/unit/users.dto.unit-spec.ts
@@ -1,5 +1,5 @@
 import { validate } from "class-validator";
-import { CreateUserDto } from "./users.dto";
+import { CreateUserDto } from "../../src/auth/dto/users.dto";
 
 describe("CreateUserDto", () => {
   let createUserDto;


### PR DESCRIPTION
## 요약

- 유료 디자인 구매 관련 테스트 코드 작성
- 네이버 로그인 관련 테스트 코드 작성

## 변경 사항

### 유료 디자인 구매 관련 테스트 코드 작성
- PurchaseService의 purchaseDesign 메서드 통합 테스트
- PurchaseDesignDto 단위 테스트

### 네이버 로그인 관련 테스트 코드 작성
- AuthService의 naverSignIn 메서드 통합 테스트

## 참고 사항

- 이전에 API만 먼저 PR 머지를 시키고 못썼던 테스트 코드를 작성한 PR
- 몇몇 테스트나 엣지 케이스의 경우 테스트 DB 초기화 기능의 부재로 현재 구현하기 매우 어렵거나 번거로워, 추후 테스트 DB 초기화 및 독립 환경 구축 시도 시 일괄적으로 수정 예정

## 이슈 번호

close #216 
