### PR TITLE
[Refactor] 로그인 API 응답 수정 및 리팩토링

### DIFF
--- a/BE/src/auth/auth.module.ts
+++ b/BE/src/auth/auth.module.ts
@@ -19,9 +19,6 @@ import { NaverOAuthStrategy } from "./strategies/naver.strategy";
     PassportModule.register({ defaultStrategy: "jwt" }),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
-      signOptions: {
-        expiresIn: process.env.JWT_ACCESS_TOKEN_TIME,
-      },
     }),
   ],
   controllers: [AuthController],

--- a/BE/src/auth/dto/auth-access-token.dto.ts
+++ b/BE/src/auth/dto/auth-access-token.dto.ts
@@ -1,7 +1,9 @@
 export class AccessTokenDto {
   accessToken: string;
+  nickname: string;
 
-  constructor(accessToken: string) {
+  constructor(accessToken: string, nickname: string) {
     this.accessToken = accessToken;
+    this.nickname = nickname;
   }
 }


### PR DESCRIPTION
## 요약
- 로그인 API 수정

## 변경 사항
### 로그인 API 수정
- 로그인 API의 응답에 현재 사용자의 nickname을 같이 보내도록 수정
  - 이를 위해 AccessTokenDto에 nickname 추가
  - createUserTokens 메서드의 파라미터로 nickname을 추가하여 AccessTokenDto에 넣도록 함. 이를 위해 createUserTokens를 사용하는 모든 메서드에서 nickname을 넣어서 호출하도록 수정
- expiresIn 옵션이 AuthModule과 AuthService에 중복적으로 들어갔기 때문에, AuthModule의 expiresIn 옵션을 제거함
  - AuthModule에서 사용하는 expiresIn 옵션은 모든 JWT 토큰에 적용되기 때문에 액세스 토큰과 리프레시 토큰에 대한 다른 옵션을 적용할 수 없어 제거함

## 참고 사항

- createUserTokens에 user 객체를 그대로 넘겨서 메서드 안에서 userId와 nickname을 풀어서 넣는 방법과 지금처럼 userId와 nickname값을 넘기는 방법 중 뭐가 더 좋을지 모르겠네요...
### 실행 결과
![image](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/53ed05b2-dd8f-49c2-adc0-cc580e6e635e)



## 이슈 번호

close #220 
