### PR TITLE
[Feat] 새 일기 작성 시 별가루 적립 및 조회 API 구현

### DIFF
--- a/BE/src/auth/users.repository.ts
+++ b/BE/src/auth/users.repository.ts
@@ -42,4 +42,9 @@ export class UsersRepository {
   async getUserByUserId(userId: string): Promise<User | null> {
     return User.findOne({ where: { userId } });
   }
+
+  async accrueCredits(user: User, amount: number): Promise<void> {
+    user.credit += amount;
+    await user.save();
+  }
 }

--- a/BE/src/diaries/diaries.module.ts
+++ b/BE/src/diaries/diaries.module.ts
@@ -11,6 +11,7 @@ import { ShapesRepository } from "src/shapes/shapes.repository";
 import { TagsRepository } from "src/tags/tags.repository";
 import { HttpModule } from "@nestjs/axios";
 import { Line } from "src/lines/lines.entity";
+import { UsersRepository } from "src/auth/users.repository";
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { Line } from "src/lines/lines.entity";
     DiariesRepository,
     TagsRepository,
     ShapesRepository,
+    UsersRepository,
   ],
 })
 export class DiariesModule {}

--- a/BE/src/diaries/diaries.repository.ts
+++ b/BE/src/diaries/diaries.repository.ts
@@ -12,6 +12,7 @@ import { NotFoundException } from "@nestjs/common";
 import { Tag } from "src/tags/tags.entity";
 import { ReadDiaryDto } from "./dto/diaries.read.dto";
 import { SentimentDto } from "./dto/diaries.sentiment.dto";
+import { Between } from "typeorm";
 
 export class DiariesRepository {
   async createDiary(
@@ -119,5 +120,23 @@ export class DiariesRepository {
     }
 
     return found;
+  }
+
+  async getDiaryByToday(userId: string): Promise<Diary[]> {
+    const currentDate = new Date();
+    const [year, month, date] = [
+      currentDate.getFullYear(),
+      currentDate.getMonth(),
+      currentDate.getDate(),
+    ];
+    const startDate = new Date(year, month, date, 0, 0, 0, 0);
+    const endDate = new Date(year, month, date, 23, 59, 59, 999);
+
+    const diaryList = await Diary.find({
+      where: { user: { userId }, createdDate: Between(startDate, endDate) },
+      withDeleted: true,
+    });
+
+    return diaryList;
   }
 }

--- a/BE/src/purchase/purchase.controller.ts
+++ b/BE/src/purchase/purchase.controller.ts
@@ -18,6 +18,11 @@ import { CreditDto } from "./dto/purchase.credit.dto";
 export class PurchaseController {
   constructor(private purchaseService: PurchaseService) {}
 
+  @Get("/credit")
+  async getCreditBalanceByUser(@GetUser() user: User): Promise<CreditDto> {
+    return new CreditDto(user.credit);
+  }
+
   @Post("/design")
   async purchaseDesign(
     @GetUser() user: User,


### PR DESCRIPTION
## 요약

- 별가루 조회 API 구현
- 새 일기 작성 시 30 별가루 적립

## 변경 사항

### 별가루 조회 API 구현
- `/purchase/credit` GET 요청 시 credit 반환 및 200 OK 응답

### 새 일기 작성 시 30 별가루 적립

- 아래 함수를 통해 현재 작성되는 일기가 새로운 일기인지 확인
- createdDate를 조건으로 검사 (실제 일기 저장 시간 기준)
- soft delete된 일기도 포함하여 별가루 적립 남용 방지
- new. Date(), mysql 검사 모두 UTC 기준으로 실행

```ts
  async getDiaryByToday(userId: string): Promise<Diary[]> {
    const currentDate = new Date();
    const [year, month, date] = [
      currentDate.getFullYear(),
      currentDate.getMonth(),
      currentDate.getDate(),
    ];
    const startDate = new Date(year, month, date, 0, 0, 0, 0);
    const endDate = new Date(year, month, date, 23, 59, 59, 999);

    const diaryList = await Diary.find({
      where: { user: { userId }, createdDate: Between(startDate, endDate) },
      withDeleted: true,
    });

    return diaryList;
  }
``` 

## 참고 사항

- 결제 모듈을 적용할 수 없어 일기 작성 시 별가루 30개 적립
  - 임시로 30개로 적용
- 테스트 코드 추후 작성 필요

## 이슈 번호

close #237 
