### PR TITLE
[Feat] 별자리 편집 모드 내 별 이동 기능 구현

### DIFF
--- a/FE/src/atoms/starAtom.js
+++ b/FE/src/atoms/starAtom.js
@@ -6,6 +6,7 @@ const starAtom = atom({
     mode: "create",
     drag: true,
     selected: null,
+    points: [],
   },
 });
 

--- a/FE/src/components/DiaryModal/DiaryDeleteModal.js
+++ b/FE/src/components/DiaryModal/DiaryDeleteModal.js
@@ -8,7 +8,7 @@ import lastPageAtom from "../../atoms/lastPageAtom";
 import ModalWrapper from "../../styles/Modal/ModalWrapper";
 
 function DiaryDeleteModal(props) {
-  const { refetch } = props;
+  const { refetch, pointsRefetch } = props;
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
   const userState = useRecoilValue(userAtom);
   const [lastPageState, setLastPageState] = useRecoilState(lastPageAtom);
@@ -40,6 +40,7 @@ function DiaryDeleteModal(props) {
       })
       .then(() => {
         refetch();
+        pointsRefetch();
       });
   }
 

--- a/FE/src/components/DiaryModal/DiaryReadModal.js
+++ b/FE/src/components/DiaryModal/DiaryReadModal.js
@@ -59,7 +59,7 @@ async function getDiary(accessToken, diaryUuid, setUserState) {
 }
 
 function DiaryReadModal(props) {
-  const { refetch } = props;
+  const { refetch, pointsRefetch } = props;
   const [diaryState, setDiaryState] = useRecoilState(diaryAtom);
   const [userState, setUserState] = useRecoilState(userAtom);
   const [lastPageState, setLastPageState] = useRecoilState(lastPageAtom);
@@ -172,7 +172,9 @@ function DiaryReadModal(props) {
             />
           </DiaryModalIcon>
         </DiaryModalEmotionBar>
-        {diaryState.isDelete ? <DiaryDeleteModal refetch={refetch} /> : null}
+        {diaryState.isDelete ? (
+          <DiaryDeleteModal refetch={refetch} pointsRefetch={pointsRefetch} />
+        ) : null}
         <ModalSideButtonWrapper>
           <ModalSideButton
             onClick={() => {


### PR DESCRIPTION
## 요약

- 별자리 편집 모드 내 별 이동 기능 구현

https://github.com/boostcampwm2023/web08-ByeolSoop/assets/67178684/40872551-fab1-44b9-bd5f-88ca6918849c

## 변경 사항

- 별 클릭 시 해당 별의 정보를 저장하고 빈 공간 클릭 시 일기 수정 요청
- 일기 수정 성공 시 별, 별자리 정보 refetch
- 별자리 정보를 Recoil을 통해 관리하고 일기 삭제 시 refetch

## 참고 사항

- 선택한 별을 사용자에게 알려주는 기능 추가 필요

## 이슈 번호

close #242 
