### PR TITLE
[Fix] 클라이언트 IP를 환경에 따라 다르게 받도록 수정

### DIFF
--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -29,6 +29,9 @@ export class AuthService {
   ): Promise<LoginResponseDto> {
     const { userId, password } = authCredentialsDto;
     const user = await this.usersRepository.getUserByUserId(userId);
+    const requestIp = request.headers["x-forwarded-for"]
+      ? (request.headers["x-forwarded-for"] as string)
+      : request.ip;
     if (!user) {
       throw new NotFoundException("존재하지 않는 아이디입니다.");
     }
@@ -38,7 +41,7 @@ export class AuthService {
     }
 
     const { nickname, premium } = user;
-    const accessToken = await this.createUserTokens(userId, request.ip);
+    const accessToken = await this.createUserTokens(userId, requestIp);
     return new LoginResponseDto(accessToken, nickname, premium);
   }
 
@@ -48,6 +51,9 @@ export class AuthService {
 
   async reissueAccessToken(request: Request): Promise<LoginResponseDto> {
     const expiredAccessToken = request.headers.authorization.split(" ")[1];
+    const requestIp = request.headers["x-forwarded-for"]
+      ? (request.headers["x-forwarded-for"] as string)
+      : request.ip;
 
     // 만료된 액세스 토큰을 직접 디코딩
     const base64Payload = expiredAccessToken.split(".")[1];
@@ -59,31 +65,37 @@ export class AuthService {
     const { nickname, premium } = await User.findOne({
       where: { userId },
     });
-    const accessToken = await this.createUserTokens(userId, request.ip);
+    const accessToken = await this.createUserTokens(userId, requestIp);
     return new LoginResponseDto(accessToken, nickname, premium);
   }
 
   async naverSignIn(user: User, request: Request): Promise<LoginResponseDto> {
     const { userId, nickname, premium } = user;
     const provider = providerEnum.NAVER;
+    const requestIp = request.headers["x-forwarded-for"]
+      ? (request.headers["x-forwarded-for"] as string)
+      : request.ip;
 
     if (!(await User.findOne({ where: { userId, provider } }))) {
       await user.save();
     }
 
-    const accessToken = await this.createUserTokens(userId, request.ip);
+    const accessToken = await this.createUserTokens(userId, requestIp);
     return new LoginResponseDto(accessToken, nickname, premium);
   }
 
   async kakaoSignIn(user: User, request: Request): Promise<LoginResponseDto> {
     const { userId, nickname, premium } = user;
     const provider = providerEnum.KAKAO;
+    const requestIp = request.headers["x-forwarded-for"]
+      ? (request.headers["x-forwarded-for"] as string)
+      : request.ip;
 
     if (!(await User.findOne({ where: { userId, provider } }))) {
       await user.save();
     }
 
-    const accessToken = await this.createUserTokens(userId, request.ip);
+    const accessToken = await this.createUserTokens(userId, requestIp);
     return new LoginResponseDto(accessToken, nickname, premium);
   }
 

--- a/BE/src/auth/guard/auth.jwt-guard.ts
+++ b/BE/src/auth/guard/auth.jwt-guard.ts
@@ -45,7 +45,9 @@ export class JwtAuthGuard extends NestAuthGuard("jwt") {
     }
 
     const request = context.switchToHttp().getRequest();
-    const requestIp = request.ip;
+    const requestIp = request.headers["x-forwarded-for"]
+      ? (request.headers["x-forwarded-for"] as string)
+      : request.ip;
     const accessToken = request.headers.authorization.split(" ")[1];
 
     const refreshToken = await this.redisClient.get(request.user.userId);


### PR DESCRIPTION
## 요약

- 클라이언트 IP를 환경에 따라 다르게 받도록 수정

## 변경 사항

### 클라이언트 IP를 환경에 따라 다르게 받도록 수정
- 현재 환경이 배포 환경인 경우 x-forwarded-for 헤더에서 IP를 받도록 함
- 현재 환경이 개발 환경인 경우 그대로 request.ip에서 IP를 받도록 함
- 이러한 수정 사항을 authService와 JwtAuthGuard에 적용

## 참고 사항

- [개발일지](https://www.notion.so/byeolsoop/NGINX-IP-f7ecd6e6b6c14e7d9e015f9ae365bd86?pvs=4)

## 이슈 번호

close #256
