### PR TITLE
[Feat] 광고 제거 구매 여부 API 구현

### DIFF
--- a/BE/src/auth/auth.controller.ts
+++ b/BE/src/auth/auth.controller.ts
@@ -35,7 +35,7 @@ export class AuthController {
     const loginResponseDto: LoginResponseDto =
       await this.authService.kakaoSignIn(user, request);
     return {
-      url: `${process.env.FRONTEND_URL}?access-token=${loginResponseDto.accessToken}&nickname=${loginResponseDto.nickname}&premium=${loginResponseDto.premium}`,
+      url: `${process.env.FRONTEND_URL}?access-token=${loginResponseDto.accessToken}&nickname=${loginResponseDto.nickname}`,
     };
   }
 
@@ -49,7 +49,7 @@ export class AuthController {
     const loginResponseDto: LoginResponseDto =
       await this.authService.naverSignIn(user, request);
     return {
-      url: `${process.env.FRONTEND_URL}?access-token=${loginResponseDto.accessToken}&nickname=${loginResponseDto.nickname}&premium=${loginResponseDto.premium}`,
+      url: `${process.env.FRONTEND_URL}?access-token=${loginResponseDto.accessToken}&nickname=${loginResponseDto.nickname}`,
     };
   }
 

--- a/BE/src/auth/auth.service.ts
+++ b/BE/src/auth/auth.service.ts
@@ -40,9 +40,9 @@ export class AuthService {
       throw new NotFoundException("올바르지 않은 비밀번호입니다.");
     }
 
-    const { nickname, premium } = user;
+    const { nickname } = user;
     const accessToken = await this.createUserTokens(userId, requestIp);
-    return new LoginResponseDto(accessToken, nickname, premium);
+    return new LoginResponseDto(accessToken, nickname);
   }
 
   async signOut(user: User): Promise<void> {
@@ -62,15 +62,15 @@ export class AuthService {
 
     const userId = expiredResult.userId;
 
-    const { nickname, premium } = await User.findOne({
+    const { nickname } = await User.findOne({
       where: { userId },
     });
     const accessToken = await this.createUserTokens(userId, requestIp);
-    return new LoginResponseDto(accessToken, nickname, premium);
+    return new LoginResponseDto(accessToken, nickname);
   }
 
   async naverSignIn(user: User, request: Request): Promise<LoginResponseDto> {
-    const { userId, nickname, premium } = user;
+    const { userId, nickname } = user;
     const provider = providerEnum.NAVER;
     const requestIp = request.headers["x-forwarded-for"]
       ? (request.headers["x-forwarded-for"] as string)
@@ -81,11 +81,11 @@ export class AuthService {
     }
 
     const accessToken = await this.createUserTokens(userId, requestIp);
-    return new LoginResponseDto(accessToken, nickname, premium);
+    return new LoginResponseDto(accessToken, nickname);
   }
 
   async kakaoSignIn(user: User, request: Request): Promise<LoginResponseDto> {
-    const { userId, nickname, premium } = user;
+    const { userId, nickname } = user;
     const provider = providerEnum.KAKAO;
     const requestIp = request.headers["x-forwarded-for"]
       ? (request.headers["x-forwarded-for"] as string)
@@ -96,7 +96,7 @@ export class AuthService {
     }
 
     const accessToken = await this.createUserTokens(userId, requestIp);
-    return new LoginResponseDto(accessToken, nickname, premium);
+    return new LoginResponseDto(accessToken, nickname);
   }
 
   private async createUserTokens(

--- a/BE/src/auth/dto/auth-credential.dto.ts
+++ b/BE/src/auth/dto/auth-credential.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, Length, Matches } from "class-validator";
+import { IsNotEmpty, IsString, Matches } from "class-validator";
 
 export class AuthCredentialsDto {
   @IsNotEmpty({ message: "유저 아이디는 비어있지 않아야 합니다." })

--- a/BE/src/auth/dto/login-response.dto.ts
+++ b/BE/src/auth/dto/login-response.dto.ts
@@ -1,13 +1,9 @@
-import { premiumStatus } from "src/utils/enum";
-
 export class LoginResponseDto {
   accessToken: string;
   nickname: string;
-  premium: premiumStatus;
 
-  constructor(accessToken: string, nickname: string, premium: premiumStatus) {
+  constructor(accessToken: string, nickname: string) {
     this.accessToken = accessToken;
     this.nickname = nickname;
-    this.premium = premium;
   }
 }

--- a/BE/src/auth/dto/users.dto.ts
+++ b/BE/src/auth/dto/users.dto.ts
@@ -1,10 +1,4 @@
-import {
-  IsString,
-  Length,
-  MaxLength,
-  Matches,
-  IsNotEmpty,
-} from "class-validator";
+import { IsString, MaxLength, Matches, IsNotEmpty } from "class-validator";
 
 export class CreateUserDto {
   @IsNotEmpty({ message: "아이디는 비어있지 않아야 합니다." })

--- a/BE/src/auth/guard/auth.jwt-guard.ts
+++ b/BE/src/auth/guard/auth.jwt-guard.ts
@@ -5,7 +5,6 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { AuthGuard as NestAuthGuard } from "@nestjs/passport";
-import { access } from "fs";
 import * as jwt from "jsonwebtoken";
 import { Redis } from "ioredis";
 import { InjectRedis } from "@liaoliaots/nestjs-redis";

--- a/BE/src/purchase/dto/purchase.design.dto.ts
+++ b/BE/src/purchase/dto/purchase.design.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsIn, IsNotEmpty } from "class-validator";
+import { IsIn, IsNotEmpty } from "class-validator";
 import { designEnum, domainEnum } from "src/utils/enum";
 
 export class PurchaseDesignDto {

--- a/BE/src/purchase/dto/purchase.premium.dto.ts
+++ b/BE/src/purchase/dto/purchase.premium.dto.ts
@@ -1,0 +1,9 @@
+import { premiumStatus } from "src/utils/enum";
+
+export class PremiumDto {
+  premium: premiumStatus;
+
+  constructor(premium: premiumStatus) {
+    this.premium = premium;
+  }
+}

--- a/BE/src/purchase/purchase.controller.ts
+++ b/BE/src/purchase/purchase.controller.ts
@@ -12,6 +12,7 @@ import { PurchaseDesignDto, PurchaseListDto } from "./dto/purchase.design.dto";
 import { GetUser } from "src/auth/get-user.decorator";
 import { User } from "src/auth/users.entity";
 import { CreditDto } from "./dto/purchase.credit.dto";
+import { PremiumDto } from "./dto/purchase.premium.dto";
 
 @Controller("purchase")
 @UseGuards(JwtAuthGuard)
@@ -40,5 +41,10 @@ export class PurchaseController {
   @Post("/premium")
   async purchasePremium(@GetUser() user: User): Promise<CreditDto> {
     return this.purchaseService.purchasePremium(user);
+  }
+
+  @Get("/premium")
+  async getPremiumStatus(@GetUser() user: User): Promise<PremiumDto> {
+    return this.purchaseService.getPremiumStatus(user);
   }
 }

--- a/BE/src/purchase/purchase.service.ts
+++ b/BE/src/purchase/purchase.service.ts
@@ -5,6 +5,7 @@ import { PurchaseRepository } from "./purchase.repository";
 import { Purchase } from "./purchase.entity";
 import { designEnum, domainEnum, premiumStatus } from "src/utils/enum";
 import { CreditDto } from "./dto/purchase.credit.dto";
+import { PremiumDto } from "./dto/purchase.premium.dto";
 
 @Injectable()
 export class PurchaseService {
@@ -87,5 +88,9 @@ export class PurchaseService {
     result["ground"] = groundPurchase;
     result["sky"] = skyPurchase;
     return result;
+  }
+
+  async getPremiumStatus(user: User): Promise<PremiumDto> {
+    return new PremiumDto(user.premium);
   }
 }

--- a/BE/src/tags/tags.controller.ts
+++ b/BE/src/tags/tags.controller.ts
@@ -1,7 +1,0 @@
-import { Controller, Get } from "@nestjs/common";
-import { TagsService } from "./tags.service";
-
-@Controller("tags")
-export class TagsController {
-  constructor(private tagsService: TagsService) {}
-}

--- a/BE/src/tags/tags.module.ts
+++ b/BE/src/tags/tags.module.ts
@@ -1,14 +1,12 @@
 import { Module } from "@nestjs/common";
-import { TagsController } from "./tags.controller";
-import { TagsService } from "./tags.service";
 import { TagsRepository } from "./tags.repository";
 import { Tag } from "./tags.entity";
 import { TypeOrmModule } from "@nestjs/typeorm";
 
 @Module({
   imports: [TypeOrmModule.forFeature([Tag])],
-  controllers: [TagsController],
-  providers: [TagsService, TagsRepository],
+  controllers: [],
+  providers: [TagsRepository],
   exports: [TagsRepository],
 })
 export class TagsModule {}

--- a/BE/src/tags/tags.service.ts
+++ b/BE/src/tags/tags.service.ts
@@ -1,7 +1,0 @@
-import { Injectable } from "@nestjs/common";
-import { TagsRepository } from "./tags.repository";
-
-@Injectable()
-export class TagsService {
-  constructor(private tagsRepository: TagsRepository) {}
-}


### PR DESCRIPTION
## 요약

- 광고 제거 구매 여부 API 구현

## 변경 사항

### 광고 제거 구매 여부 API 구현
- /purchase/premium GET 요청 시 해당 유저의 광고 제거 구매 여부를 응답하는 API를 구현
- 기존에 로그인 시 응답하던 데이터 중 광고 제거 구매 여부를 제거

## 참고 사항

- 전체 파일을 보면서 사용하지 않는 import 변수를 제거함
- TagsController, TagsService는 아무 역할도 하지 않는 파일이기 때문에 제거함
### 실행 결과
![image](https://github.com/boostcampwm2023/web08-ByeolSoop/assets/49023630/286e17df-9318-4b18-9ec5-42a5ace27a0a)


## 이슈 번호

close #260 
