### PR TITLE
[Fix] 리스트 보기에서 수정 시도 시 별이 원점으로 가는 이슈 수정

### DIFF
--- a/FE/src/components/DiaryModal/DiaryListModal.js
+++ b/FE/src/components/DiaryModal/DiaryListModal.js
@@ -44,7 +44,9 @@ function DiaryListModal() {
       setDiaryState((prev) => ({
         ...prev,
         diaryUuid: selectedDiary?.uuid,
-        diaryPoint: `${selectedDiary?.coordinate.x},${selectedDiary?.coordinate.y},${selectedDiary?.coordinate.z}`,
+        diaryPoint: `${selectedDiary?.coordinate.x * 100000},${
+          selectedDiary?.coordinate.y * 100000
+        },${selectedDiary?.coordinate.z * 100000}`,
       }));
     }
   }, [selectedDiary]);


### PR DESCRIPTION
## 요약

- 리스트 보기에서 수정 시도 시 별이 원점으로 가는 이슈 수정

## 변경 사항

- 원인을 찾아보니 리스트 보기에서는 일기를 선택할 때 point가 100000이 곱해지지 않는 이슈가 있었음
- refetch에서 100000을 나누는 로직이 있어 원점에 생성된다고 느낀 것이지, 원점은 아니었다!
- 100000을 곱해서 diaryState에 저장하니 문제 해결

## 참고 사항

- Cannot assign to read only property 'x' of object '#<Object>' 에러가 발생했었기에 이 문제도 따로 처리해야되나 싶었는데, 이유는 모르겠으나 동시에 처리됨. 이후 확인 요망

## 이슈 번호

close #251 
