### PR TITLE
[Feat] 샘플 계정 중복 로그인 허용

### DIFF
--- a/BE/src/auth/guard/auth.jwt-guard.ts
+++ b/BE/src/auth/guard/auth.jwt-guard.ts
@@ -49,6 +49,15 @@ export class JwtAuthGuard extends NestAuthGuard("jwt") {
       : request.ip;
     const accessToken = request.headers.authorization.split(" ")[1];
 
+    const accessTokenBody = jwt.verify(
+      accessToken,
+      process.env.JWT_SECRET,
+    ) as jwt.JwtPayload;
+
+    if (accessTokenBody.userId === "sample") {
+      return true;
+    }
+
     const refreshToken = await this.redisClient.get(request.user.userId);
 
     const refreshTokenBody = jwt.verify(


### PR DESCRIPTION
## 요약

- 샘플 계정 중복 로그인 허용

## 변경 사항

### 샘플 계정 중복 로그인 허용
- 아이디가 "sample"일 시 리프레시 토큰 검사를 하지 않고 중복 로그인을 허용하도록 수정

## 참고 사항

- 발표 상황에서 sample에 대한 중복 로그인 시 403 오류가 발생하는 것을 방지하기 위한 수정 사항

## 이슈 번호

close #274 
